### PR TITLE
fix: ignore tox.ini on releases

### DIFF
--- a/config/default/setup.cfg.j2
+++ b/config/default/setup.cfg.j2
@@ -17,6 +17,7 @@ ignore =
 ignore =
     .editorconfig
     .meta.toml
+    tox.ini
 {% for line in additional_check_manifest_ignores %}
     %(line)s
 {% endfor %}


### PR DESCRIPTION
There is no real benefit of havign `tox.ini` in releases, tell `check-manifest` to ignore it :-)

Closes #5 