### PR TITLE
feat(tox): install and run check-manifest

### DIFF
--- a/config/default/lint-requirements.txt.j2
+++ b/config/default/lint-requirements.txt.j2
@@ -1,4 +1,5 @@
 black==22.12.0
+check-manifest==0.49
 codespell==2.2.2
 flake8==6.0.0
 isort==5.11.4

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -28,8 +28,10 @@ skip_install = true
 deps =
     flake8
     codespell
+    check-manifest
     -c lint-requirements.txt
 commands =
     sh -c '{[testenv]py_files} | xargs flake8 *.py'
     sh -c '{[testenv]py_files} | xargs codespell *.py'
     sh -c '{[testenv]rst_files} | xargs codespell *.rst'
+    check-manifest


### PR DESCRIPTION
Add a new tool on `tox.ini` `lint` section: check-manifest.

This tool reports if there are any mismatch with the git checkout and what would go on a release.

This helps to avoid the so called _brown bag releases_.

Closes #6 