### PR TITLE
feat(tox): use git ls-files

### DIFF
--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -4,8 +4,8 @@ envlist =
     lint
 
 [testenv]
-py_files = find %(dist_path)s -name "*.py"
-rst_files = find %(dist_path)s -name "*.rst"
+py_files = git ls-files "*.py"
+text_files = git ls-files "*.rst" "*.md"
 allowlist_externals =
     sh
 
@@ -18,9 +18,9 @@ deps =
     black
     -c lint-requirements.txt
 commands =
-    sh -c '{[testenv]py_files} | xargs pyupgrade --py38-plus *.py'
-    sh -c '{[testenv]py_files} | xargs isort *.py'
-    sh -c '{[testenv]py_files} | xargs black *.py'
+    sh -c '{[testenv]py_files} | xargs pyupgrade --py38-plus'
+    sh -c '{[testenv]py_files} | xargs isort'
+    sh -c '{[testenv]py_files} | xargs black'
 
 [testenv:lint]
 description = run linters that will help improve the code style
@@ -30,6 +30,6 @@ deps =
     codespell
     -c lint-requirements.txt
 commands =
-    sh -c '{[testenv]py_files} | xargs flake8 *.py'
-    sh -c '{[testenv]py_files} | xargs codespell *.py'
-    sh -c '{[testenv]rst_files} | xargs codespell *.rst'
+    sh -c '{[testenv]py_files} | xargs flake8'
+    sh -c '{[testenv]py_files} | xargs codespell'
+    sh -c '{[testenv]text_files} | xargs codespell'


### PR DESCRIPTION
To use a more powerful/better way to get the files that need to be passed to formatters or linters.

Closes #11 