### PR TITLE
Fix setup.cfg rendering.

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -152,7 +152,6 @@ class PackageConfiguration:
         return self.copy_with_meta(
             'setup.cfg.j2',
             self.path / 'setup.cfg',
-            self.config_type,
             additional_check_manifest_ignores=extra_check_manifest_ignores,
         )
 


### PR DESCRIPTION
We still passed self.config_type, which was interpreted as meta_hint, so at the top of the generated setup.cfg we got a string 'default', giving it a bad syntax. Fixes https://github.com/plone/meta/issues/23