### PR TITLE
Support setup.metadata and setup.options in .meta.toml.

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -152,7 +152,6 @@ class PackageConfiguration:
         return self.copy_with_meta(
             'setup.cfg.j2',
             self.path / 'setup.cfg',
-            self.config_type,
             additional_check_manifest_ignores=extra_check_manifest_ignores,
         )
 

--- a/config/default/packages.txt
+++ b/config/default/packages.txt
@@ -4,3 +4,4 @@
 plone.batching
 plone.subrequest
 plone.supermodel
+Products.CMFPlacefulWorkflow

--- a/config/default/setup.cfg.j2
+++ b/config/default/setup.cfg.j2
@@ -1,3 +1,17 @@
+{% if metadata %}
+[metadata]
+    {% for key, value in metadata %}
+%(key)s = %(value)s
+    {% endfor %}
+
+{% endif %}
+{% if options %}
+[options]
+    {% for key, value in options %}
+%(key)s = %(value)s
+    {% endfor %}
+
+{% endif %}
 [bdist_wheel]
 universal = 0
 

--- a/config/shared/toml_encoder.py
+++ b/config/shared/toml_encoder.py
@@ -1,6 +1,14 @@
 import toml
 
 
+def dump_string(value):
+    if "\n" in value:
+        # Return a multi line string as a multi line string,
+        # instead of on one line with literal '\n' in it.
+        return f'"""\n{value}"""'
+    return toml.encoder._dump_str(value)
+
+
 class TomlArraySeparatorEncoderWithNewline(toml.TomlArraySeparatorEncoder):
     """Special version indenting the first element of and array.
 
@@ -14,6 +22,7 @@ class TomlArraySeparatorEncoderWithNewline(toml.TomlArraySeparatorEncoder):
         super(TomlArraySeparatorEncoderWithNewline, self).__init__(
             _dict=_dict, preserve=preserve, separator=separator)
         self.indent_first_line = indent_first_line
+        self.dump_funcs[str] = dump_string
 
     def dump_list(self, v):
         t = []

--- a/config/shared/utils.py
+++ b/config/shared/utils.py
@@ -1,0 +1,38 @@
+from copy import deepcopy
+
+import textwrap
+
+
+def cleanup_data_for_jinja(data):
+    """Take a dictionary and cleanup before passing to Jinja.
+
+    This makes it easier to insert in a Jinja template.
+    Note: Initially this changed the dictionary inline, but then any changes
+    are also written back to .meta.toml, if that is where the dictionary comes from.
+    So return a new dictionary.
+
+    * Fixes multi line strings.
+
+      With this as input:
+
+        classifiers = '''
+            Environment :: Web Environment
+            Framework :: Plone
+        '''
+
+      toml reads it as:
+
+        '    Environment :: Web Environment\n    Framework :: Plone\n'
+
+      We want to have the initial newline back.
+
+    """
+    if not data:
+        return
+    new_data = deepcopy(data)
+    for key, value in new_data.items():
+        if not isinstance(value, str):
+            continue
+        if "\n" in value and value.startswith(" "):
+            new_data[key] = "\n" + value
+    return new_data


### PR DESCRIPTION
Insert these in setup.cfg.
Fixes https://github.com/plone/meta/issues/24

This PR is based on the (much smaller) branch from PR #25.

Sample contents of `.meta.toml`:

```
[setup.metadata]
long_description = "file: README.rst, CHANGES.rst"
classifiers = """
    Development Status :: 5 - Production/Stable
    Environment :: Web Environment
    Framework :: Plone
"""

[setup.options]
include_package_data = true
zip_safe = false
packages = [
    ]
python_requires = ">= 3.8"
install_requires = """
    setuptools>=36.2
    plone.app.caching
    plone.app.iterate
    plone.app.upgrade
    plone.restapi
    plone.volto
    Products.CMFPlacefulWorkflow
    Products.CMFPlone
"""
```

Resulting setup.cfg is:

```
[metadata]
long_description = file: README.rst, CHANGES.rst
classifiers =
    Development Status :: 5 - Production/Stable
    Environment :: Web Environment
    Framework :: Plone

[options]
include_package_data = True
zip_safe = False
packages = []
python_requires = >= 3.8
install_requires =
    setuptools>=36.2
    plone.app.caching
    plone.app.iterate
    plone.app.upgrade
    plone.restapi
    plone.volto
    Products.CMFPlacefulWorkflow
    Products.CMFPlone
```