### PR TITLE
Configure z3c.dependencychecker

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -105,10 +105,10 @@ but that does not mean it has to be this way!
 
 See ``zopefoundation/meta`` for plenty of examples
 of options that can be added to the configuration files
-if the need arises. 
+if the need arises.
 
 ``.meta.toml`` file is added inside the package repository.
-This file stores the template name and commit id 
+This file stores the template name and commit id
 of the *meta* repository at the time of the run.
 This file is generated during the configuration run,
 if it does not exist or at least gets updated.

--- a/config/README.rst
+++ b/config/README.rst
@@ -120,6 +120,12 @@ Example:
     template = "default"
     commit-id = "< commit-hash >"
 
+    [dependencies]
+    mappings = [
+        "Zope = ['Products.Five', 'ZTUtils']",
+        ]
+    ignores = "['plone.app.locales', 'plone.batching']"
+
 Meta Options
 ````````````
 
@@ -130,6 +136,18 @@ template
 commit-id
   Commit of the meta repository, which was used for the last configuration run.
   Currently read-only.
+
+Dependencies
+````````````
+
+Options to configure `z3c.dependencychecker`.
+
+ignores
+  Text line of a list of packages that should be ignored.
+
+mappings
+  List of text lines with mappings of imports and packages providing them.
+  i.e. `Zope` provides `Products.Five` and other importable packages.
 
 Hints
 -----

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -191,10 +191,16 @@ class PackageConfiguration:
     def pyproject_toml(self):
         codespell_ignores = self.cfg_option(
             'codespell', 'additional-ignores')
+        dependencies_ignores = self.cfg_option(
+            'dependencies', 'ignores')
+        dependencies_mapping = self.cfg_option(
+            'dependencies', 'mappings')
 
         return self.copy_with_meta(
             'pyproject.toml.j2',
-            codespell_ignores=codespell_ignores
+            codespell_ignores=codespell_ignores,
+            dependencies_ignores=dependencies_ignores,
+            dependencies_mapping=dependencies_mapping,
         )
 
     def tox(self):

--- a/config/default/lint-requirements.txt.j2
+++ b/config/default/lint-requirements.txt.j2
@@ -5,3 +5,4 @@ flake8==6.0.0
 isort==5.11.4
 pyroma==4.1
 pyupgrade==3.3.1
+z3c.dependencychecker==2.10

--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -39,8 +39,18 @@ profile = "plone"
 
 [tool.black]
 target-version = ["py38"]
-
 {% if codespell_ignores %}
+
 [tool.codespell]
 ignore-words-list = "%(codespell_ignores)s"
+{% endif %}
+{% if dependencies_ignores or dependencies_mapping %}
+
+[tool.dependencychecker]
+{% if dependencies_ignores %}
+ignore-packages = %(dependencies_ignores)s
+{% endif %}
+{% for line in dependencies_mapping %}
+%(line)s
+{% endfor %}
 {% endif %}

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -38,3 +38,11 @@ commands =
     sh -c '{[testenv]text_files} | xargs codespell'
     check-manifest
     pyroma -n 10 .
+
+[testenv:dependencies]
+description = check if the package defines all its dependencies
+deps =
+    z3c.dependencychecker
+    -c lint-requirements.txt
+commands =
+    dependencychecker


### PR DESCRIPTION
Closes #12 

See it in action on https://github.com/plone/plone.batching/pull/35 and https://github.com/plone/plone.subrequest/pull/28

For now I added it as a new `dependencies` `tox` environment that is not run by default.

Should we do that at some point though? 🤔 🍀 