### PR TITLE
Configure testing

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -135,6 +135,9 @@ Example:
     [codespell]
     additional-ignores = "typo,wurd"
 
+    [tests]
+    gha = true
+
 Meta Options
 ````````````
 
@@ -173,6 +176,14 @@ Options to configure `codespell`.
 
 additional-ignores
   List of words that should be ignored by `codespell`.
+
+Tests
+`````
+
+Options related to the testing the distribution.
+
+gha
+  Whether it should run the tests on GitHub Actions.
 
 Hints
 -----

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -283,6 +283,7 @@ class PackageConfiguration:
         self._add_project_to_config_type_list()
 
         files_changed = [
+            self.path / '.meta.toml',
             self.editorconfig(),
             self.lint_requirements(),
             self.linting_yml(),

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -182,6 +182,14 @@ class PackageConfiguration:
         workflows.mkdir(parents=True, exist_ok=True)
         return self.copy_with_meta('linting.yml.j2', workflows / 'linting.yml')
 
+    def test_yml(self):
+        should_run_tests_on_gha = self.cfg_option('tests', 'gha', default=False)
+        if not should_run_tests_on_gha:
+            return
+        workflows = self.path / '.github' / 'workflows'
+        workflows.mkdir(parents=True, exist_ok=True)
+        return self.copy_with_meta('tests.yml.j2', workflows / 'tests.yml')
+
     def editorconfig(self):
         return self.copy_with_meta('editorconfig', self.path / '.editorconfig')
 
@@ -291,10 +299,12 @@ class PackageConfiguration:
             self.editorconfig(),
             self.lint_requirements(),
             self.linting_yml(),
+            self.test_yml(),
             self.pyproject_toml(),
             self.setup_cfg(),
             self.tox(),
         ]
+        files_changed = filter(None, files_changed)
 
         self.remove_old_files()
         self.remove_toml_empty_sections()

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -204,7 +204,11 @@ class PackageConfiguration:
         )
 
     def tox(self):
-        return self.copy_with_meta('tox.ini.j2')
+        package_name = self.path.name
+        return self.copy_with_meta(
+            'tox.ini.j2',
+            package_name=package_name
+        )
 
     def copy_with_meta(
             self, template_name, destination=None,

--- a/config/default/linting.yml.j2
+++ b/config/default/linting.yml.j2
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
-    name: Lint code
+  lint:
+    name: Format and lint code
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/config/default/tests.yml.j2
+++ b/config/default/tests.yml.j2
@@ -1,0 +1,34 @@
+name: Testing
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Run tests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        os: ["ubuntu-22.04"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Run tests
+        run: tox -e test

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -60,3 +60,14 @@ deps =
     -c lint-requirements.txt
 commands =
     sh -c 'pipdeptree --exclude setuptools,pipdeptree,wheel --graph-output svg > dependencies.svg'
+
+[testenv:test]
+description = run the distribution's tests
+deps =
+    %(package_name)s[test]
+    pytest
+    gocept.pytestlayer
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    pip install -e .
+    pytest


### PR DESCRIPTION
Run distributions' tests on on GitHub Actions 🎉 

Not enabled by default, a new option must be set on `.meta.toml` so that this is enabled.

The `tox` sections is created nonetheless, so even if not enabled, one can check if it does work or not 🍀 