### PR TITLE
fix: avoid zpretty error

### DIFF
--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -24,8 +24,8 @@ commands =
     sh -c '{[testenv]py_files} | xargs pyupgrade --py38-plus'
     sh -c '{[testenv]py_files} | xargs isort'
     sh -c '{[testenv]py_files} | xargs black'
-    sh -c '{[testenv]xml_files} | xargs zpretty -x -i'
-    sh -c '{[testenv]zcml_files} | xargs zpretty -z -i'
+    sh -c '{[testenv]xml_files} | xargs zpretty -x -i || true'
+    sh -c '{[testenv]zcml_files} | xargs zpretty -z -i || true'
 
 [testenv:lint]
 description = run linters that will help improve the code style


### PR DESCRIPTION
If no files are given `zpretty` breaks.

Until https://github.com/collective/zpretty/issues/97 is fixed and released 😄 