### PR TITLE
Merge tox dependencies environments

### DIFF
--- a/config/default/packages.txt
+++ b/config/default/packages.txt
@@ -14,3 +14,4 @@ borg.localrole
 five.intid
 plone.scale
 plone.browserlayer
+plone.cachepurging

--- a/config/default/packages.txt
+++ b/config/default/packages.txt
@@ -13,3 +13,4 @@ plone.dexterity
 borg.localrole
 five.intid
 plone.scale
+plone.browserlayer

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -27,18 +27,13 @@ commands =
     pre-commit run -a
 
 [testenv:dependencies]
-description = check if the package defines all its dependencies
+description = check if the package defines all its dependencies and generate a graph out of them
 deps =
     z3c.dependencychecker==2.10
-commands =
-    dependencychecker
-
-[testenv:dependencies-graph]
-description = generate a graph with the distribution dependencies
-deps =
     pipdeptree==2.3.3
     graphviz  # optional dependency of pipdeptree
 commands =
+    dependencychecker
     sh -c 'pipdeptree --exclude setuptools,pipdeptree,wheel --graph-output svg > dependencies.svg'
 
 [testenv:test]


### PR DESCRIPTION
Rather than having two of them, a single one with all the tools, that anyway revolve around the same topic sounds better resource wise