### PR TITLE
Enable tests always

### DIFF
--- a/config/default/packages.txt
+++ b/config/default/packages.txt
@@ -16,3 +16,4 @@ plone.scale
 plone.browserlayer
 plone.cachepurging
 plone.i18n
+plone.base

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -2,6 +2,7 @@
 envlist =
     format
     lint
+    test
 
 [testenv]
 allowlist_externals =
@@ -37,12 +38,11 @@ commands =
     sh -c 'pipdeptree --exclude setuptools,pipdeptree,wheel --graph-output svg > dependencies.svg'
 
 [testenv:test]
-description = run the tests of the distribution
+usedevelop = true
 deps =
-    %(package_name)s[test]
-    pytest
-    gocept.pytestlayer
+    zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
 commands =
-    pip install -e .[test]
-    pytest
+    zope-testrunner --test-path={toxinidir} -s %(package_name)s
+extras =
+    test

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -30,12 +30,12 @@ commands =
 [testenv:dependencies]
 description = check if the package defines all its dependencies and generate a graph out of them
 deps =
-    z3c.dependencychecker==2.10
-    pipdeptree==2.3.3
+    z3c.dependencychecker==2.11
+    pipdeptree==2.5.1
     graphviz  # optional dependency of pipdeptree
 commands =
     dependencychecker
-    sh -c 'pipdeptree --exclude setuptools,pipdeptree,wheel --graph-output svg > dependencies.svg'
+    sh -c 'pipdeptree --exclude setuptools,pipdeptree,wheel,pipdeptree,z3c.dependencychecker,zope.interface,zope.component --graph-output svg > dependencies.svg'
 
 [testenv:test]
 usedevelop = true


### PR DESCRIPTION
With these changes, it _should be possible_ ™️ to mass-enable all repositories to run tests.

Note that the GitHub workflow to run tests is configured centrally on plone GitHub's organization.