### PR TITLE
Plone base dependency

### DIFF
--- a/config/default/packages.txt
+++ b/config/default/packages.txt
@@ -17,3 +17,4 @@ plone.session
 plone.subrequest
 plone.supermodel
 Products.CMFPlacefulWorkflow
+plone.app.content

--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -44,13 +44,23 @@ target-version = ["py38"]
 [tool.codespell]
 ignore-words-list = "%(codespell_ignores)s"
 {% endif %}
-{% if dependencies_ignores or dependencies_mapping %}
 
 [tool.dependencychecker]
+Zope = [
+  # Zope own provided namespaces
+  'App', 'OFS', 'Products.Five', 'Products.OFSP', 'Products.PageTemplates',
+  'Products.SiteAccess', 'Shared', 'Testing', 'ZPublisher', 'ZTUtils',
+  'Zope2', 'webdav', 'zmi',
+  # Zope dependencies
+  'Acquisition', 'DateTime', 'transaction', 'zExceptions', 'ZODB', 'zope.component',
+  'zope.configuration', 'zope.container', 'zope.deferredimport', 'zope.event',
+  'zope.exceptions', 'zope.globalrequest', 'zope.i18n', 'zope.i18nmessageid',
+  'zope.interface', 'zope.lifecycleevent', 'zope.location', 'zope.publisher',
+  'zope.schema', 'zope.security', 'zope.site', 'zope.traversing', 'AccessControl',
+]
 {% if dependencies_ignores %}
 ignore-packages = %(dependencies_ignores)s
 {% endif %}
 {% for line in dependencies_mapping %}
 %(line)s
 {% endfor %}
-{% endif %}

--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -62,6 +62,7 @@ Zope = [
   'setuptools', 'AccessControl', 'Products.BTreeFolder2', 'Products.CMFCore',
   'Products.CMFDynamicViewFTI', 'zope.deprecation',
 ]
+python-dateutil = ['dateutil']
 {% if dependencies_ignores %}
 ignore-packages = %(dependencies_ignores)s
 {% endif %}

--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -58,6 +58,10 @@ Zope = [
   'zope.interface', 'zope.lifecycleevent', 'zope.location', 'zope.publisher',
   'zope.schema', 'zope.security', 'zope.site', 'zope.traversing', 'AccessControl',
 ]
+'plone.base' = [
+  'setuptools', 'AccessControl', 'Products.BTreeFolder2', 'Products.CMFCore',
+  'Products.CMFDynamicViewFTI', 'zope.deprecation',
+]
 {% if dependencies_ignores %}
 ignore-packages = %(dependencies_ignores)s
 {% endif %}


### PR DESCRIPTION
Closes #52 

With this, when configuring a package, we don't need to list all its dependencies, but can hide quite a few of them with `plone.base`.

Should we do the same with `Zope`, here technically we need a mapping, as `Zope` provides quite a few random namespaces (`OFS`, `ZTUtils`, a few `Products.`, `Testing` ...).

Another candidate to get added on the `plone.base` could be `setuptools`, there is no need to keep it on all and every single distribution, right?

Specially with the idea that it is less and less important to mention it...


__Edit:__ and now I see #52 😅 