### PR TITLE
Do not ignore setuptools when plone.base is installed.

### DIFF
--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -59,7 +59,7 @@ Zope = [
   'zope.schema', 'zope.security', 'zope.site', 'zope.traversing', 'AccessControl',
 ]
 'plone.base' = [
-  'setuptools', 'AccessControl', 'Products.BTreeFolder2', 'Products.CMFCore',
+  'AccessControl', 'Products.BTreeFolder2', 'Products.CMFCore',
   'Products.CMFDynamicViewFTI', 'zope.deprecation',
 ]
 python-dateutil = ['dateutil']


### PR DESCRIPTION
When I run the coredev buildout I now get this:

```
Develop distribution: plone.portlet.static 4.0.1.dev0
uses namespace packages but the distribution does not require setuptools.
Develop distribution: plone.portlet.collection 4.0.1.dev0
uses namespace packages but the distribution does not require setuptools.
Develop distribution: plone.z3cform 2.0.1.dev0
uses namespace packages but the distribution does not require setuptools.
Develop distribution: plone.app.querystring 2.0.2.dev0
uses namespace packages but the distribution does not require setuptools.
```

It is a [warning from buildout](https://github.com/buildout/buildout/issues/526).

It seems to work, but I don't trust it.

See same comment I made in the [PR that added this](https://github.com/plone/meta/pull/59#issuecomment-1468917939).