### PR TITLE
tox -e test: allow passing arguments.

### DIFF
--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -46,6 +46,6 @@ deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
 commands =
-    zope-testrunner --test-path={toxinidir} -s %(package_name)s
+    zope-testrunner --test-path={toxinidir} -s %(package_name)s {posargs}
 extras =
     test


### PR DESCRIPTION
For example: `tox -e test -- -D` to get a debug prompt after a test failure. Note that you need `--` to separate the options that you pass to tox from the options that you pass to the command in the tox environment. See also https://tox.wiki/en/latest/config.html#substitutions-for-positional-arguments-in-commands

Used in https://github.com/plone/plone.portlets/pull/9