### PR TITLE
Allow updating the current branch.

### DIFF
--- a/config/README.rst
+++ b/config/README.rst
@@ -82,6 +82,7 @@ The following arguments are supported.
 --branch
   Define a specific git branch name to be created for the changes. By default
   the script creates one which includes the name of the configuration type.
+  Use "current" to update the current branch.
 
 The following options are only needed one time as their values are stored in
 ``.meta.toml.``.

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -67,7 +67,7 @@ def handle_command_line_arguments():
         default=None,
         help='Define a git branch name to be used for the changes. '
         'If not given it is constructed automatically and includes '
-        'the configuration type')
+        'the configuration type. Use "current" to update the current branch.')
 
     args = parser.parse_args()
     return args
@@ -208,6 +208,9 @@ class PackageConfiguration:
         )
 
     def news_entry(self):
+        if self.args.branch_name == 'current':
+            print('Updating current branch, so I do not add a news entry.')
+            return
         news = self.path / 'news'
         news.mkdir(parents=True, exist_ok=True)
 

--- a/config/shared/git.py
+++ b/config/shared/git.py
@@ -10,6 +10,11 @@ def get_commit_id():
 
 def get_branch_name(override, config_type):
     """Get the default branch name but prefer override if not empty."""
+    if override == "current":
+        # Note: can be empty if not on a branch.
+        override = call(
+            'git', 'branch', '--show-current',
+            capture_output=True).stdout.splitlines()[0]
     return (
         override
         or f"config-with-{config_type}-template-{get_commit_id()}")


### PR DESCRIPTION
For example:

```
bin/python config-package.py --branch current ../../6.0/src/plone.portlets
```

Use case:

1. Configure a package, make a PR.
2. Discover a problem, fix it in `plone/meta`.
3. Configure the package again.
4. You now have two branches called `config-with-default-template-something` and get confused: which was the right one?

So in step 3 you call with with `--branch current` and your current branch gets updated with new commits.