### PR TITLE
Call zope-testrunner with --all so robot tests are run.

### DIFF
--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -46,6 +46,6 @@ deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
 commands =
-    zope-testrunner --test-path={toxinidir} -s %(package_name)s {posargs}
+    zope-testrunner --all --test-path={toxinidir} -s %(package_name)s {posargs}
 extras =
     test


### PR DESCRIPTION
I have included this in https://github.com/plone/plone.portlet.collection/pull/38 but that has no robot tests.
I am trying it in plone.app.contenttypes, and there extra tests are indeed run.  They fail though, looking into that.