### PR TITLE
Let repositories define the python versions

### DIFF
--- a/shared-workflows/tests.yml
+++ b/shared-workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ${{ fromJSON(vars.TEST_PYTHON_VERSIONS) }}
         os: ${{ fromJSON(vars.TEST_OS_VERSIONS) }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
... that are being used to run the GHA workflows in.

The default stays the same, only python 3.11, but a repository might want to enforce a set of python versions.

For that one has to override the `TEST_PYTHON_VERSIONS` on the repository variables.