### PR TITLE
Declare all Zope, CMFCore and plone.base dependencies

### DIFF
--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -52,15 +52,34 @@ Zope = [
   'Products.SiteAccess', 'Shared', 'Testing', 'ZPublisher', 'ZTUtils',
   'Zope2', 'webdav', 'zmi',
   # Zope dependencies
-  'Acquisition', 'DateTime', 'transaction', 'zExceptions', 'ZODB', 'zope.component',
-  'zope.configuration', 'zope.container', 'zope.deferredimport', 'zope.event',
-  'zope.exceptions', 'zope.globalrequest', 'zope.i18n', 'zope.i18nmessageid',
-  'zope.interface', 'zope.lifecycleevent', 'zope.location', 'zope.publisher',
-  'zope.schema', 'zope.security', 'zope.site', 'zope.traversing', 'AccessControl',
+  'AccessControl', 'Acquisition', 'AuthEncoding', 'beautifulsoup4', 'BTrees',
+  'cffi', 'Chameleon', 'DateTime', 'DocumentTemplate', 'ExtensionClass',
+  'MultiMapping', 'multipart', 'PasteDeploy', 'Persistence', 'persistent',
+  'pycparser', 'python-gettext', 'pytz', 'RestrictedPython', 'roman', 'six',
+  'soupsieve', 'transaction', 'waitress', 'WebOb', 'WebTest', 'WSGIProxy2',
+  'z3c.pt', 'zc.lockfile', 'ZConfig', 'zExceptions', 'ZODB', 'zodbpickle',
+  'zope.annotation', 'zope.browser', 'zope.browsermenu', 'zope.browserpage',
+  'zope.browserresource', 'zope.cachedescriptors', 'zope.component',
+  'zope.configuration', 'zope.container', 'zope.contentprovider',
+  'zope.contenttype', 'zope.datetime', 'zope.deferredimport',
+  'zope.deprecation', 'zope.dottedname', 'zope.event', 'zope.exceptions',
+  'zope.filerepresentation', 'zope.globalrequest', 'zope.hookable',
+  'zope.i18n', 'zope.i18nmessageid', 'zope.interface', 'zope.lifecycleevent',
+  'zope.location', 'zope.pagetemplate', 'zope.processlifetime', 'zope.proxy',
+  'zope.ptresource', 'zope.publisher', 'zope.schema', 'zope.security',
+  'zope.sequencesort', 'zope.site', 'zope.size', 'zope.structuredtext',
+  'zope.tal', 'zope.tales', 'zope.testbrowser', 'zope.testing',
+  'zope.traversing', 'zope.viewlet'
+]
+'Products.CMFCore' = [
+  'docutils', 'five.localsitemanager', 'Missing', 'Products.BTreeFolder2',
+  'Products.GenericSetup', 'Products.MailHost', 'Products.PythonScripts',
+  'Products.StandardCacheManagers', 'Products.ZCatalog', 'Record',
+  'zope.sendmail', 'Zope'
 ]
 'plone.base' = [
-  'AccessControl', 'Products.BTreeFolder2', 'Products.CMFCore',
-  'Products.CMFDynamicViewFTI', 'zope.deprecation',
+  'plone.batching', 'plone.registry', 'plone.schema','plone.z3cform',
+  'Products.CMFCore', 'Products.CMFDynamicViewFTI',
 ]
 python-dateutil = ['dateutil']
 {% if dependencies_ignores %}


### PR DESCRIPTION
In order to reduce dependencies to declare, define `Zope` with all dependencies, add `Products.CMFCore` with its dependencies and correctly define `plone.base`. Use transitive dependencies here. It seems like `dependencychecker` correctly interprets them. 

At some point we want to declare this for `Products.CMFPlone` as well, but not now.

This closes #58. 