### PR TITLE
Implement `skip` to codespell configuration

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -188,6 +188,8 @@ class PackageConfiguration:
     def pyproject_toml(self):
         codespell_ignores = self.cfg_option(
             'codespell', 'additional-ignores')
+        codespell_skip = self.cfg_option(
+            'codespell', 'skip')
         dependencies_ignores = self.cfg_option(
             'dependencies', 'ignores')
         dependencies_mapping = self.cfg_option(
@@ -196,6 +198,7 @@ class PackageConfiguration:
         return self.copy_with_meta(
             'pyproject.toml.j2',
             codespell_ignores=codespell_ignores,
+            codespell_skip=codespell_skip,
             dependencies_ignores=dependencies_ignores,
             dependencies_mapping=dependencies_mapping,
         )

--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -39,10 +39,16 @@ profile = "plone"
 
 [tool.black]
 target-version = ["py38"]
-{% if codespell_ignores %}
 
+{% if codespell_ignores or codespell_skip%}
 [tool.codespell]
+{%if codespell_ignores %}
 ignore-words-list = "%(codespell_ignores)s"
+{% endif %}
+{%if codespell_skip %}
+skip = "%(codespell_skip)s"
+{% endif %}
+
 {% endif %}
 
 [tool.dependencychecker]


### PR DESCRIPTION
example `.meta.toml`:

```
[codespell]
skip = "*.map,*.zcml"
```
