### PR TITLE
Smaller dependency tox environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,24 @@ it does _not_ install its hooks by default.
 
 ## Dependencies
 
-Another `tox` environment allows you to check
+This `tox` environment allows you to check
 if the distribution defines all its dependencies on `setup.py`.
 
 ```shell
 tox -e dependencies
+```
+
+Note: this `tox` environment does not run on GitHub Actions as of now.
+
+## Dependencies graph
+
+This `tox` environment generates an SVG graph with all the package dependencies.
+
+Really useful to see if unwanted dependencies are being pulled in,
+or to diagnose circular dependencies.
+
+```shell
+tox -e dependencies-graph
 ```
 
 Note: this `tox` environment does not run on GitHub Actions as of now.

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -30,14 +30,22 @@ commands =
     pre-commit run -a
 
 [testenv:dependencies]
-description = check if the package defines all its dependencies and generate a graph out of them
+description = check if the package defines all its dependencies
+skip_install = true
 deps =
+    build
     z3c.dependencychecker==2.11
+commands =
+    python -m build --sdist --no-isolation
+    dependencychecker
+
+[testenv:dependencies-graph]
+description = generate a graph out of the package's dependencies
+deps =
     pipdeptree==2.5.1
     graphviz  # optional dependency of pipdeptree
 commands =
-    dependencychecker
-    sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,z3c.dependencychecker,zope.interface,zope.component --graph-output svg > dependencies.svg'
+    sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,zope.interface,zope.component --graph-output svg > dependencies.svg'
 
 [testenv:test]
 use_develop = true

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -40,7 +40,7 @@ commands =
     sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,z3c.dependencychecker,zope.interface,zope.component --graph-output svg > dependencies.svg'
 
 [testenv:test]
-usedevelop = true
+use_develop = true
 constrain_package_deps = true
 set_env = ROBOT_BROWSER=headlesschrome
 deps =
@@ -52,7 +52,7 @@ extras =
     test
 
 [testenv:coverage]
-usedevelop = true
+use_develop = true
 constrain_package_deps = true
 set_env = ROBOT_BROWSER=headlesschrome
 deps =


### PR DESCRIPTION
Closes #84 

Not sure if we want to _pin_ `build` version. They are on version `0.10.0` which does not seem terribly stable to me 😅 

As long as we don't start running it on CI we might need to pin it. And looking at past releases they don't do that many releases either, 3 releases (0.8, 8.9 and 0.10) within 2022 and 2023.

I used the long form of the command line options to make it more readable 🍀 

And as the idea is only to get the `egg-info` building only the `sdist` is probably enough, otherwise it builds both `sdist` and `whl` and with one is more than enough.