### PR TITLE
feat(gha): show coverage report in job summaries

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,42 @@
+name: Coverage
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+  # allow this workflow to be called
+  # by other workflows from other repositories
+  workflow_call:
+
+jobs:
+  test:
+    name: Coverage report
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: "3.11"
+        os: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Run coverage
+        run: |
+          tox -q -e coverage >> $GITHUB_STEP_SUMMARY

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -68,7 +68,7 @@ deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
 commands =
-    coverage run {envbindir}/zope-testrunner --all --test-path={toxinidir} -s %(package_name)s {posargs}
+    coverage run {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir} -s %(package_name)s {posargs}
     coverage report -m --format markdown
 extras =
     test


### PR DESCRIPTION
Part of #72 

Create a _reusable workflow_ that runs `tox -e coverage` and redirects the output to this magic `$GITHUB_STEP_SUMMARY` variable that allows one to create [job summaries](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/). 🎉 

I'm merging it, otherwise I can not test it 😅 