### PR TITLE
feat: do not run tox by default

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -62,6 +62,12 @@ def handle_command_line_arguments():
         help='type of the configuration to be used, see README.rst. '
         'Only required when running on a repository for the first time.')
     parser.add_argument(
+        '--tox',
+        dest='run_tox',
+        action='store_true',
+        default=False,
+        help='Whether to run tox after configuring the repository.')
+    parser.add_argument(
         '--branch',
         dest='branch_name',
         default=None,
@@ -364,7 +370,8 @@ class PackageConfiguration:
 
         self.remove_old_files()
         self.remove_toml_empty_sections()
-        self.run_tox()
+        if self.args.run_tox:
+            self.run_tox()
 
         with change_dir(self.path):
             updating = git_branch(self.branch_name)


### PR DESCRIPTION
I'm not finding it much useful to get tox to run `format` and `lint` environments when configuring a new package, I stash and drop the changes and start anew anyways.