### PR TITLE
Enforce no dependency cycles

### DIFF
--- a/.github/workflows/circular.yml
+++ b/.github/workflows/circular.yml
@@ -1,0 +1,35 @@
+# Workflow meant to be used by external repositories
+# that are configured with this `meta` repository
+name: Circular
+on:
+  # allow this workflow to be called
+  # by other workflows from other repositories
+  workflow_call:
+
+jobs:
+  test:
+    name: Circular dependencies report
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        os: ["ubuntu-latest"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Run circular dependencies check
+        run: |
+          tox -e circular

--- a/config/default/meta.yml.j2
+++ b/config/default/meta.yml.j2
@@ -21,3 +21,5 @@ jobs:
     uses: plone/meta/.github/workflows/dependencies.yml@master
   release-ready:
     uses: plone/meta/.github/workflows/release_ready.yml@master
+  circular:
+    uses: plone/meta/.github/workflows/circular.yml@master

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -91,3 +91,17 @@ commands =
     python -m build --sdist --no-isolation
     twine check dist/*
 %(extra_lines)s
+
+[testenv:circular]
+usedevelop = true
+deps =
+    pipdeptree
+    pipforester
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    # Generate the full dependency tree
+    sh -c 'pipdeptree -j > forest.json'
+    # Generate a DOT graph with the circular dependencies, if any
+    pipforester -i forest.json -o forest.dot --cycles
+    # Report if there are any circular dependencies, i.e. error if there are any
+    pipforester -i forest.json --check-cycles


### PR DESCRIPTION
Now that @jensens and friends ironed all(?) dependency cycles, is time to ensure that we do not regress on that ⛓️ 

With `pipforester` we can detect those cycles, if the distribution declares all dependencies, and return an error on a GitHub Action ✨ 

Closes #77