### PR TITLE
feat(pre-commit): check python versions

### DIFF
--- a/config/default/pre-commit-config.yaml.j2
+++ b/config/default/pre-commit-config.yaml.j2
@@ -39,3 +39,8 @@ repos:
     rev: "4.2"
     hooks:
     -   id: pyroma
+-   repo: https://github.com/mgedmin/check-python-versions
+    rev: "0.21.2"
+    hooks:
+    -   id: check-python-versions
+        args: ['--only', 'setup.py,pyproject.toml']


### PR DESCRIPTION
Add another linter on `pre-commit`: https://pypi.org/project/check-python-versions/

It checks that all python versions specific across the repository are consistent.

For now, we only check it on `setup.py` and `pyproject.toml` as we are not adding on `tox.ini` all python versions, as we already have Jenkins for that, at least for now.

Closes #44 