### PR TITLE
feat(workflows): check release readiness

### DIFF
--- a/.github/workflows/release_ready.yml
+++ b/.github/workflows/release_ready.yml
@@ -1,0 +1,35 @@
+# Workflow meant to be used by external repositories
+# that are configured with this `meta` repository
+name: Release status
+on:
+  # allow this workflow to be called
+  # by other workflows from other repositories
+  workflow_call:
+
+jobs:
+  test:
+    name: Release status
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        os: ["ubuntu-latest"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-
+      - name: Install dependencies
+        run: python -m pip install tox
+      - name: Check release status
+        run: |
+          tox -e release-check

--- a/config/default/meta.yml.j2
+++ b/config/default/meta.yml.j2
@@ -19,3 +19,5 @@ jobs:
     uses: plone/meta/.github/workflows/coverage.yml@master
   dependencies:
     uses: plone/meta/.github/workflows/dependencies.yml@master
+  release-ready:
+    uses: plone/meta/.github/workflows/release_ready.yml@master

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -75,4 +75,19 @@ commands =
     coverage report -m --format markdown
 extras =
     test
+
+[testenv:release-check]
+skip_install = true
+deps =
+    twine
+    build
+    towncrier
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    # fake version to not have to install the package
+    # we build the change log as news entries might break
+    # the README that is displayed on PyPI
+    towncrier build --version=100.0.0 --yes
+    python -m build --sdist --no-isolation
+    twine check dist/*
 %(extra_lines)s


### PR DESCRIPTION
Use `towncrier` and `twine` to ensure that a PR will produce a ready to release artifact.

This way we lower release managers efforts.

Closes #98 