### PR TITLE
cleanup(setup.cfg): remove bdist_wheel section

### DIFF
--- a/config/default/setup.cfg.j2
+++ b/config/default/setup.cfg.j2
@@ -12,9 +12,6 @@
     {% endfor %}
 
 {% endif %}
-[bdist_wheel]
-universal = 0
-
 [flake8]
 doctests = 1
 ignore =


### PR DESCRIPTION
`wheel` by default, in python 3, already creates a python 3 only wheel archive, there is no need to keep the configuration around.

Part of #56 