### PR TITLE
feat(codespell): provide ignore and skip defaults

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -215,9 +215,9 @@ class PackageConfiguration:
 
     def pyproject_toml(self):
         codespell_ignores = self.cfg_option(
-            'codespell', 'additional-ignores')
+            'codespell', 'additional-ignores', default='')
         codespell_skip = self.cfg_option(
-            'codespell', 'skip')
+            'codespell', 'skip', default='')
         dependencies_ignores = self.cfg_option(
             'dependencies', 'ignores')
         dependencies_mapping = self.cfg_option(

--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -40,16 +40,9 @@ profile = "plone"
 [tool.black]
 target-version = ["py38"]
 
-{% if codespell_ignores or codespell_skip%}
 [tool.codespell]
-{%if codespell_ignores %}
-ignore-words-list = "%(codespell_ignores)s"
-{% endif %}
-{%if codespell_skip %}
-skip = "%(codespell_skip)s"
-{% endif %}
-
-{% endif %}
+ignore-words-list = "discreet,%(codespell_ignores)s"
+skip = "*.po,%(codespell_skip)s"
 
 [tool.dependencychecker]
 Zope = [


### PR DESCRIPTION
At the end I left the default dictionary, we can always change it, but providing `discreet` as a default value makes the configuration easier actually 😅 

Closes #57 
