### PR TITLE
feat: add a .gitignore file

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -196,6 +196,17 @@ class PackageConfiguration:
             **options
         )
 
+    def gitignore(self):
+        options = self._get_options_for(
+            'gitignore',
+            ('extra_lines', )
+        )
+        return self.copy_with_meta(
+            'gitignore.j2',
+            self.path / '.gitignore',
+            **options
+        )
+
     def pre_commit_config(self):
         options = self._get_options_for(
             'pre_commit', ('codespell_extra_lines', 'extra_lines',)
@@ -364,6 +375,7 @@ class PackageConfiguration:
         ]
         methods = (
             self.editorconfig,
+            self.gitignore,
             self.pre_commit_config,
             self.pyproject_toml,
             self.tox,

--- a/config/default/gitignore.j2
+++ b/config/default/gitignore.j2
@@ -1,0 +1,37 @@
+# python related
+*.egg-info
+*.pyc
+*.pyo
+
+# tools related
+build/
+.coverage
+coverage.xml
+dist/
+docs/_build
+__pycache__/
+.tox
+.vscode/
+
+# venv / buildout related
+bin/
+develop-eggs/
+eggs/
+.eggs/
+etc/
+.installed.cfg
+lib/
+lib64
+.mr.developer.cfg
+parts/
+pyvenv.cfg
+var/
+
+%(extra_lines)s
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##


### PR DESCRIPTION
The entries in `.gitignore` are the most comment ones that I found doing a `cat */.gitignore | sort | uniq -c | sort -g` on all plone/zope packages inside `buidlout.coredev/src` 🍀 

Do I miss anything? JS/CSS ignores? 🤔 

Closes #62 