### PR TITLE
Tox: fail when env is not defined.

### DIFF
--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -18,6 +18,17 @@ envlist =
 #  """
 ##
 
+[testenv]
+skip_install = true
+allowlist_externals =
+    echo
+    false
+# Make sure typos like `tox -e formaat` are caught instead of silently doing nothing.
+# See https://github.com/tox-dev/tox/issues/2858.
+commands =
+    echo "Unrecognized environment name {envname}"
+    false
+
 [testenv:format]
 description = automatically reformat code
 skip_install = true
@@ -49,6 +60,7 @@ commands =
 
 [testenv:dependencies-graph]
 description = generate a graph out of the dependencies of the package
+skip_install = false
 allowlist_externals =
     sh
 deps =
@@ -60,6 +72,7 @@ commands =
 [testenv:test]
 description = run the distribution tests
 use_develop = true
+skip_install = false
 constrain_package_deps = true
 set_env = ROBOT_BROWSER=headlesschrome
 deps =
@@ -73,6 +86,7 @@ extras =
 [testenv:coverage]
 description = get a test coverage report
 use_develop = true
+skip_install = false
 constrain_package_deps = true
 set_env = ROBOT_BROWSER=headlesschrome
 deps =
@@ -103,7 +117,8 @@ commands =
 
 [testenv:circular]
 description = ensure there are no cyclic dependencies
-usedevelop = true
+use_develop = true
+skip_install = false
 allowlist_externals =
     sh
 deps =


### PR DESCRIPTION
Do this by defining a standard testenv that fails. Other test envs always have to override the commands.

To fail fast, we set `skip_install = true`.
Since the other test envs also take over all settings from this standard testenv, we need to set `skip_install = true` in a few of them. Note that `use_develop = false` is already the default.

Use case: I either thought I knew, or guessed that the `circular` env was actually called `cyclic`.

Before:

```
$ tox -e cyclic
.pkg: install_requires> python -I -m pip install 'setuptools>=40.8.0' wheel
.pkg: _optional_hooks> python /Users/maurits/.local/pipx/venvs/tox/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: get_requires_for_build_editable> python /Users/maurits/.local/pipx/venvs/tox/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: install_requires_for_build_editable> python -I -m pip install wheel
.pkg: get_requires_for_build_sdist> python /Users/maurits/.local/pipx/venvs/tox/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_wheel> python /Users/maurits/.local/pipx/venvs/tox/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
.pkg: build_sdist> python /Users/maurits/.local/pipx/venvs/tox/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
cyclic: install_package_deps> python -I -m pip install AccessControl Zope setuptools zope.interface zope.schema
cyclic: install_package> python -I -m pip install --force-reinstall --no-deps /Users/maurits/community/plone-coredev/6.0/src/plone.batching/.tox/.tmp/package/1/plone.batching-2.0.6.dev0.tar.gz
.pkg: _exit> python /Users/maurits/.local/pipx/venvs/tox/lib/python3.11/site-packages/pyproject_api/_backend.py True setuptools.build_meta __legacy__
  cyclic: OK (19.02 seconds)
  congratulations :) (19.16 seconds)
```

Reaction: "Hey, all is well, no cyclic dependencies!"

After:

```
$ tox -e cyclic
cyclic: commands[0]> echo 'Unrecognized environment name cyclic'
cyclic: commands[1]> false
cyclic: exit 1 (0.01 seconds) /Users/maurits/community/plone-coredev/6.0/src/plone.batching> false pid=82262
  cyclic: FAIL code 1 (0.62=setup[0.01]+cmd[0.61,0.01] seconds)
  evaluation failed :( (0.76 seconds)
```

Reaction: "Ah, I need to check the actual env name."