### PR TITLE
feat(pre-commit): allow extra configuration on zpretty

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -209,7 +209,8 @@ class PackageConfiguration:
 
     def pre_commit_config(self):
         options = self._get_options_for(
-            'pre_commit', ('codespell_extra_lines', 'extra_lines',)
+            'pre_commit',
+            ('zpretty_extra_lines', 'codespell_extra_lines', 'extra_lines',)
         )
 
         return self.copy_with_meta(

--- a/config/default/pre-commit-config.yaml.j2
+++ b/config/default/pre-commit-config.yaml.j2
@@ -20,6 +20,14 @@ repos:
     rev: 3.0.4
     hooks:
     -   id: zpretty
+%(zpretty_extra_lines)s
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  zpretty_extra_lines = """
+#  _your own configuration lines_
+#  """
+##
 -   repo: https://github.com/PyCQA/flake8
     rev: 6.0.0
     hooks:


### PR DESCRIPTION
That's a direct requirement to configure `plone.resource` with `plone/meta` in a clean way.

In `plone.resource` they want to exclude a file and do it so in `pre-commit` configuration.

This PR allows to express such a configuration. 🎉 🍀 