### PR TITLE
feat(tox): allow to install extra dependencies

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -254,7 +254,7 @@ class PackageConfiguration:
     def tox(self):
         options = self._get_options_for(
             'tox',
-            ('envlist_lines', 'config_lines', 'extra_lines')
+            ('envlist_lines', 'config_lines', 'test_extras', 'extra_lines')
         )
         test_path = ''
         if (self.path / 'src').exists():

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -82,6 +82,15 @@ commands =
     zope-testrunner --all --test-path={toxinidir}%(test_path)s -s %(package_name)s {posargs}
 extras =
     test
+%(test_extras)s
+##
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  test_extras = """
+#      tests
+#      widgets
+#  """
+##
 
 [testenv:coverage]
 description = get a test coverage report
@@ -98,6 +107,7 @@ commands =
     coverage report -m --format markdown
 extras =
     test
+%(test_extras)s
 
 [testenv:release-check]
 description = ensure that the distribution is ready to release


### PR DESCRIPTION
Some packages, like `plone.app.textfield` have `tests` rather than `test` as its extra key to define what needs to be installed for running the tests.

Allow, in general, to configure `tox`'s `test` and `coverage` environments.

See it in https://github.com/plone/plone.app.textfield/pull/53