### PR TITLE
Implement support for pytest in tox.ini

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -97,6 +97,10 @@ Example:
 template = "default"
 commit-id = "< commit-hash >"
 
+[test]
+runner = "pytest"
+path = "/tests"
+
 [dependencies]
 mappings = [
     "Zope = ['Products.Five', 'ZTUtils']",
@@ -121,6 +125,14 @@ skip = "*.zcml"
 
 `commit-id`: Commit of the meta repository, which was used for the last configuration run.
   Currently read-only.
+
+#### Test Options
+
+`runner`: Name of the test runner used by tox, by default we use `zope.testrunner`, but
+`pytest` is also supported.
+
+`path`: Base path to run tests. Default values are top-level `/tests` or `/src`.
+
 
 #### Dependencies
 

--- a/config/README.md
+++ b/config/README.md
@@ -97,9 +97,9 @@ Example:
 template = "default"
 commit-id = "< commit-hash >"
 
-[test]
-runner = "pytest"
-path = "/tests"
+[tox]
+test_runner = "pytest"
+test_path = "/tests"
 
 [dependencies]
 mappings = [
@@ -126,12 +126,12 @@ skip = "*.zcml"
 `commit-id`: Commit of the meta repository, which was used for the last configuration run.
   Currently read-only.
 
-#### Test Options
+#### Tox Options
 
-`runner`: Name of the test runner used by tox, by default we use `zope.testrunner`, but
+`test_runner`: Name of the test runner used by tox, by default we use `zope.testrunner`, but
 `pytest` is also supported.
 
-`path`: Base path to run tests. Default values are top-level `/tests` or `/src`.
+`test_path`: Base path to run tests. Default values are top-level `/tests` or `/src`.
 
 
 #### Dependencies

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -94,7 +94,6 @@ class PackageConfiguration:
         self.meta_cfg = self._read_meta_configuration()
         self.meta_cfg['meta']['template'] = self.config_type
         self.meta_cfg['meta']['commit-id'] = get_commit_id()
-        self.test_cfg = self._test_cfg()
 
     def _read_meta_configuration(self):
         """Read and update meta configuration"""
@@ -173,11 +172,10 @@ class PackageConfiguration:
     def _test_cfg(self):
         """Setup testing configuration."""
         options = self._get_options_for(
-            'test',
-            ('runner', 'path')
+            'tox',
+            ('test_runner', 'test_path')
         )
-        runner = options.get("runner", "zope.testrunner")
-        path = options.get("path")
+        path = options.get("test_path")
         if not path:
             if (self.path / 'tests').exists():
                 path = "/tests"
@@ -185,8 +183,9 @@ class PackageConfiguration:
                 path = "/src"
             else:
                 path = ""
-        options["runner"] = runner
-        options["path"] = path
+        options["test_path"] = path
+        runner = options.get("test_runner", "zope.testrunner")
+        options["test_runner"] = runner
         return options
 
     def warn_on_setup_cfg(self):
@@ -276,8 +275,7 @@ class PackageConfiguration:
             'tox',
             ('envlist_lines', 'config_lines', 'test_extras', 'extra_lines')
         )
-        options['test_runner'] = self.test_cfg["runner"]
-        options['test_path'] = self.test_cfg["path"]
+        options.update(self._test_cfg())
         options['package_name'] = self.path.name
         return self.copy_with_meta(
             'tox.ini.j2',

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -69,6 +69,41 @@ deps =
 commands =
     sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,zope.interface,zope.component --graph-output svg > dependencies.svg'
 
+{% if test_runner == "pytest" %}
+[testenv:test]
+description = run the distribution tests
+use_develop = true
+skip_install = false
+constrain_package_deps = true
+set_env = ROBOT_BROWSER=headlesschrome
+deps =
+    pytest-plone
+    pytest
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    pytest --disable-warnings {posargs} {toxinidir}%(test_path)s
+extras =
+    test
+%(test_extras)s
+
+[testenv:coverage]
+description = get a test coverage report
+use_develop = true
+skip_install = false
+constrain_package_deps = true
+set_env = ROBOT_BROWSER=headlesschrome
+deps =
+    pytest-plone
+    pytest
+    coverage
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    coverage run --source %(package_name)s -m pytest  {posargs} --disable-warnings {toxinidir}%(test_path)s
+    coverage report -m --format markdown
+extras =
+    test
+%(test_extras)s
+{% else %}
 [testenv:test]
 description = run the distribution tests
 use_develop = true
@@ -108,6 +143,7 @@ commands =
 extras =
     test
 %(test_extras)s
+{% endif %}
 
 [testenv:release-check]
 description = ensure that the distribution is ready to release


### PR DESCRIPTION
# Usage with pytest

On the target repository, add to `.meta.toml`:

```toml
[test]
runner = "pytest"
path = "/tests"

```

And re-configure the repository.

Closes #120 