### PR TITLE
Do branch coverage

### DIFF
--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -138,7 +138,7 @@ deps =
     zope.testrunner
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
 commands =
-    coverage run --source %(package_name)s {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir}%(test_path)s -s %(package_name)s {posargs}
+    coverage run --branch --source %(package_name)s {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir}%(test_path)s -s %(package_name)s {posargs}
     coverage report -m --format markdown
 extras =
     test


### PR DESCRIPTION
I was expecting the default to be `True`, but the documentation clearly says that you have to enable it:

https://coverage.readthedocs.io/en/7.2.7/branch.html

@ericof would you do a corresponding PR to add (if needed) branch coverage also to `pytest`?