### PR TITLE
Add a dot to news/.changelog_template.jinja

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -243,7 +243,7 @@ class PackageConfiguration:
         changes_extension = 'rst'
         if (self.path / 'CHANGES.md').exists():
             changes_extension = 'md'
-            destination = self.path / 'news' / 'changelog_template.jinja'
+            destination = self.path / 'news' / '.changelog_template.jinja'
             shutil.copy(
                 self.config_type_path / 'changelog_template.jinja',
                 destination

--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -9,7 +9,7 @@ underlines = ["-", ""]
 filename = "CHANGES.md"
 start_string = "<!-- towncrier release notes start -->\n"
 title_format = "## {version} ({project_date})"
-template = "news/changelog_template.jinja"
+template = "news/.changelog_template.jinja"
 underlines = ["", "", ""]
 {% endif %}
 


### PR DESCRIPTION
I got an error during the release of `plone.app.caching`: https://github.com/plone/plone.app.caching/commit/da68783f2e9ef08dc9f7c86e8f370f446ce681dc