### PR TITLE
Gitlab CI

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -29,7 +29,8 @@ Currently the files managed by `plone/meta` are the following.
 - `.editorconfig`: configuration meant to be read by code editors
 - `.flake8`: [`flake8`](https://pypi.org/project/flake8) configuration
 - `.gitignore`: list of file/folders patterns that `git` should ignore
-- `.github/workflows/meta.yml`: GitHub Actions to run the testing and QA tools on GitHub
+- `.github/workflows/meta.yml`: GitHub Actions to run the testing and QA tools on GitHub (if the repository is hosted in GitHub.com)
+- `.gitlab-ci.yml`: GitLab CI configuration (if the repository is hosted in GitLab.com)
 - `.pre-commit-config.yaml`: [`pre-commit`](https://pypi.org/project/pre-commit) configuration
 - `pyproject.toml`: configuration options for a wide variety of Python tooling
 - `tox.ini`: [`tox`](https://pypi.org/project/tox) configuration, __the most important file__
@@ -125,6 +126,25 @@ _your own configuration lines_
 ### `.github/workflows/meta.yml`
 
 _At this time there are no configuration options_.
+
+### `.gitlab-ci.yml`
+
+Add the `[gitlab]` TOML table in `.meta.toml`,
+and set the extra configuration for GitLab CI under the `extra_lines` key.
+
+```toml
+[gitlab]
+extra_lines = """
+_your own configuration lines_
+"""
+```
+
+Specify a custom docker image if the default does not fit your needs on the `custom_image` key.
+
+```toml
+[gitlab]
+custom_image = "python:3.11-bullseye"
+```
 
 ### `.pre-commit-config.yaml`
 

--- a/config/default/gitlab-ci.yml.j2
+++ b/config/default/gitlab-ci.yml.j2
@@ -1,0 +1,77 @@
+image: %(custom_image)s
+##
+# Add extra configuration options in .meta.toml:
+#  [gitlab]
+#  custom_image = "python:3.11-bullseye"
+##
+
+stages:
+  - qa
+  - test
+
+##
+# JOBS
+##
+lint:
+  stage: qa
+  script:
+    - pip install tox
+    - tox -e lint
+  except:
+    - schedules
+
+release-ready:
+  stage: qa
+  script:
+    - pip install tox
+    - tox -e release-check
+  except:
+    - schedules
+
+dependencies:
+  stage: qa
+  script:
+    - pip install tox
+    - tox -e dependencies
+  except:
+    - schedules
+
+circular-dependencies:
+  stage: qa
+  script:
+    - apt-get update
+    - apt-get install -y graphviz graphviz-dev
+    - pip install tox
+    - tox -e circular
+  except:
+    - schedules
+
+testing:
+  stage: test
+  script:
+    - pip install tox
+    - tox -e test
+  except:
+    - schedules
+
+coverage:
+  stage: test
+  script:
+    - pip install tox
+    - tox -e coverage
+  artifacts:
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+  except:
+    - schedules
+
+%(extra_lines)s
+##
+# Add extra configuration options in .meta.toml:
+#  [gitlab]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/config/shared/git.py
+++ b/config/shared/git.py
@@ -35,3 +35,9 @@ def git_branch(branch_name) -> bool:
         call('git', 'checkout', '-b', branch_name)
         updating = False
     return updating
+
+def git_server_url():
+    """Return the repository URL"""
+    output = call('git', 'remote', 'get-url', 'origin', capture_output=True)
+    url = output.stdout.splitlines()[0]
+    return url


### PR DESCRIPTION
Closes #131 

Specially relevant for projects that are not hosted in GitHub but rather in GitLab.

As it is automatically detected, given the repository URL, it is configured one or the other CI system, or none if the URL is on another git hosting.