### PR TITLE
Do not track packages

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -426,6 +426,8 @@ __Tip:__ Use `current` to update the current branch.
 
 `--tox`: whether to run `tox` on the repository. By default it is not run.
 
+`--no-track`: whether the package being configured should _not_ be added on `defaults/packages.txt`. By default, packages' names are added to it.
+
 The following options are only needed one time
 as their values are stored in `.meta.toml.`.
 

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -89,6 +89,12 @@ def handle_command_line_arguments():
         help='Define a git branch name to be used for the changes. '
         'If not given it is constructed automatically and includes '
         'the configuration type. Use "current" to update the current branch.')
+    parser.add_argument(
+        '--no-track',
+        dest='track_package',
+        action='store_false',
+        default=True,
+        help='Whether to add the package being configured in packages.txt.')
 
     args = parser.parse_args()
     return args
@@ -461,7 +467,8 @@ class PackageConfiguration:
             print('Create a PR, using the URL shown above.')
 
     def configure(self):
-        self._add_project_to_config_type_list()
+        if self.args.track_package:
+            self._add_project_to_config_type_list()
 
         files_changed = [
             self.path / '.meta.toml',


### PR DESCRIPTION
The idea of `plone/meta` and originally from `zopefoundation/meta` is to keep track of all configured packages in a file (`defaults/packages.txt` in `plone/meta`).

With this file, then you can use it with the `multi-call.py` script to mass re-configure all packages that are listed there. 🚀 

That's the desired behavior for plone/collective upstream packages, but not so much for private/forked packages 😅 

@ericof that's going to be really useful specially for companies, or maybe even collective packages that we don't want to keep them in the list of tracked projects. ✨ 🍀 