### PR TITLE
Support setting towncrier issue_format

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -242,6 +242,13 @@ check_manifest_ignores = """
 """
 ```
 
+Configure [`towncrier`](https://pypi.org/project/towncrier) [`issue_format`](https://towncrier.readthedocs.io/en/stable/configuration.html) by setting the new format in the `towncrier_issue_format` key.
+
+```toml
+[pyproject]
+towncrier_issue_format = "[#{issue}](https://github.com/plonegovbr/plonegovbr.portal/issues/{issue})"
+```
+
 Extend [`towncrier`](https://pypi.org/project/towncrier) configuration
 by setting the values for the `towncrier_extra_lines` key.
 

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -278,6 +278,7 @@ class PackageConfiguration:
                 'dependencies_ignores',
                 'dependencies_mappings',
                 'check_manifest_ignores',
+                'towncrier_issue_format',
                 'towncrier_extra_lines',
                 'isort_extra_lines',
                 'black_extra_lines',

--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -12,6 +12,9 @@ title_format = "## {version} ({project_date})"
 template = "news/.changelog_template.jinja"
 underlines = ["", "", ""]
 {% endif %}
+{% if towncrier_issue_format %}
+issue_format = "%(towncrier_issue_format)s"
+{% endif %}
 
 [[tool.towncrier.type]]
 directory = "breaking"


### PR DESCRIPTION
[towncrier](https://pypi.org/project/towncrier) supports setting a format for issues (to convert the issue number into a link pointing to the original issue), but it is not possible to use it with `plone/meta`.

This PR adds a `towncrier_issue_format` configuration option:

```toml
[pyproject]
towncrier_issue_format = "[#{issue}](https://github.com/plonegovbr/plonegovbr.portal/issues/{issue})"
```

Implements #147 