### PR TITLE
Allow to install OS dependencies

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,10 @@ on:
   # allow this workflow to be called
   # by other workflows from other repositories
   workflow_call:
+    inputs:
+      os-packages:
+        required: false
+        type: string
 
 jobs:
   test:
@@ -20,6 +24,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: install OS packages
+        if: inputs.os-packages != ''
+        run: sudo apt-get install -y ${{ inputs.os-packages }}
       - name: Cache packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,10 @@ on:
   # allow this workflow to be called
   # by other workflows from other repositories
   workflow_call:
+    inputs:
+      os-packages:
+        required: false
+        type: string
 
 jobs:
   test:
@@ -20,6 +24,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: install OS packages
+        if: inputs.os-packages != ''
+        run: sudo apt-get install -y ${{ inputs.os-packages }}
       - name: Cache packages
         uses: actions/cache@v3
         with:

--- a/config/README.md
+++ b/config/README.md
@@ -151,6 +151,14 @@ ref = "master"
 In the previous example, all GitHub workflows would come from
 the `master` branch, instead of the default `main` branch.
 
+To install specific OS level dependencies,
+note that they have to be Ubuntu package names, specify the following key:
+
+```toml
+[github]
+os_dependencies = "git libxml2"
+```
+
 Extend github workflow configuration with additional jobs
 by setting the values for the `extra_lines` key.
 
@@ -179,6 +187,15 @@ Specify a custom docker image if the default does not fit your needs on the `cus
 ```toml
 [gitlab]
 custom_image = "python:3.11-bullseye"
+```
+
+To install test/coverage specific dependencies, add the following:
+
+```toml
+[gitlab]
+os_dependencies = """
+    - apt-get install libxslt libxml2
+"""
 ```
 
 ### `.pre-commit-config.yaml`

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -350,6 +350,7 @@ class PackageConfiguration:
             (
                 'ref',
                 'jobs',
+                'os_dependencies',
                 'extra_lines',
             )
         )
@@ -367,7 +368,7 @@ class PackageConfiguration:
     def gitlab_ci(self):
         if not self.is_gitlab:
             return []
-        options = self._get_options_for('gitlab', ('custom_image', 'extra_lines', ))
+        options = self._get_options_for('gitlab', ('custom_image', 'os_dependencies', 'extra_lines' ))
         if not options['custom_image']:
             options['custom_image'] = DOCKER_IMAGE
         destination = self.path / '.gitlab-ci.yml'

--- a/config/default/gitlab-ci.yml.j2
+++ b/config/default/gitlab-ci.yml.j2
@@ -49,16 +49,32 @@ circular-dependencies:
 testing:
   stage: test
   script:
+%(os_dependencies)s
     - pip install tox
     - tox -e test
+##
+# Add extra test/coverage commands in .meta.toml:
+#  [gitlab]
+#  os_dependencies = """
+#      - apt-get install libxslt libxml2
+#  """
+##
   except:
     - schedules
 
 coverage:
   stage: test
   script:
+%(os_dependencies)s
     - pip install tox
     - tox -e coverage
+##
+# Add extra test/coverage commands in .meta.toml:
+#  [gitlab]
+#  os_dependencies = """
+#      - apt-get install libxslt libxml2
+#  """
+##
   artifacts:
     reports:
       coverage_report:

--- a/config/default/meta.yml.j2
+++ b/config/default/meta.yml.j2
@@ -14,6 +14,10 @@ jobs:
 {% for job_name in jobs %}
   %(job_name)s:
     uses: plone/meta/.github/workflows/%(job_name)s.yml@%(ref)s
+  {% if job_name in ('test', 'coverage') and os_dependencies %}
+    with:
+        os-packages: '%(os_dependencies)s'
+  {% endif %}
 {% endfor %}
 
 ##
@@ -27,6 +31,13 @@ jobs:
 #    "release_ready",
 #    "circular",
 #    ]
+##
+
+##
+# To request that some OS level dependencies get installed
+# when running tests/coverage jobs, add in .meta.toml:
+# [githb]
+# os_dependencies = "git libxml2 libxslt"
 ##
 
 %(extra_lines)s


### PR DESCRIPTION
Closes #65 

And with today's addition, we also support GitLab, not only GitHub Actions 😄 

That's going to be a bit of a _maintenance burden_ to keep two CI systems in sync... hopefully we have enough contributors for each that the maintenance is not that much 🍀 