### PR TITLE
Configuring with plone/meta

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,53 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+# See the inline comments on how to expand/tweak this configuration file
+#
+# EditorConfig Configuration file, for more details see:
+# http://EditorConfig.org
+# EditorConfig is a convention description, that could be interpreted
+# by multiple editors to enforce common coding conventions for specific
+# file types
+
+# top-most EditorConfig file:
+# Will ignore other EditorConfig files in Home directory or upper tree level.
+root = true
+
+
+[*]  # For All Files
+# Unix-style newlines with a newline ending every file
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+# Set default charset
+charset = utf-8
+# Indent style default
+indent_style = space
+# Max Line Length - a hard line wrap, should be disabled
+max_line_length = off
+
+[*.{py,cfg,ini}]
+# 4 space indentation
+indent_size = 4
+
+[*.{yml,zpt,pt,dtml,zcml}]
+# 2 space indentation
+indent_size = 2
+
+[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss,html}]  # Frontend development
+# 2 space indentation
+indent_size = 2
+
+[{Makefile,.gitmodules}]
+# Tab indentation (no size specified, but view as 4 spaces)
+indent_style = tab
+indent_size = unset
+tab_width = unset
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [editorconfig]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,22 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+# See the inline comments on how to expand/tweak this configuration file
+[flake8]
+doctests = 1
+ignore =
+    # black takes care of line length
+    E501,
+    # black takes care of where to break lines
+    W503,
+    # black takes care of spaces within slicing (list[:])
+    E203,
+    # black takes care of spaces after commas
+    E231,
+
+##
+# Add extra configuration options in .meta.toml:
+#  [flake8]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -1,0 +1,28 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+# See the inline comments on how to expand/tweak this configuration file
+name: Meta
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+jobs:
+  qa:
+    uses: plone/meta/.github/workflows/qa.yml@main
+  test:
+    uses: plone/meta/.github/workflows/test.yml@main
+  coverage:
+    uses: plone/meta/.github/workflows/coverage.yml@main
+  dependencies:
+    uses: plone/meta/.github/workflows/dependencies.yml@main
+  release-ready:
+    uses: plone/meta/.github/workflows/release_ready.yml@main
+  circular:
+    uses: plone/meta/.github/workflows/circular.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+# See the inline comments on how to expand/tweak this configuration file
+# python related
+*.egg-info
+*.pyc
+*.pyo
+
+# tools related
+build/
+.coverage
+coverage.xml
+dist/
+docs/_build
+__pycache__/
+.tox
+.vscode/
+node_modules/
+
+# venv / buildout related
+bin/
+develop-eggs/
+eggs/
+.eggs/
+etc/
+.installed.cfg
+include/
+lib/
+lib64
+.mr.developer.cfg
+parts/
+pyvenv.cfg
+var/
+
+# mxdev
+/instance/
+/.make-sentinels/
+/*-mxdev.txt
+/reports/
+/sources/
+/venv/
+.installed.txt
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [gitignore]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,0 +1,6 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+# See the inline comments on how to expand/tweak this configuration file
+[meta]
+template = "default"
+commit-id = "cfffba8c"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,84 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+# See the inline comments on how to expand/tweak this configuration file
+ci:
+    autofix_prs: false
+    autoupdate_schedule: monthly
+
+repos:
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.4.0
+    hooks:
+    -   id: pyupgrade
+        args: [--py38-plus]
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+-   repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/collective/zpretty
+    rev: 3.1.0a2
+    hooks:
+    -   id: zpretty
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  zpretty_extra_lines = """
+#  _your own configuration lines_
+#  """
+##
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  flake8_extra_lines = """
+#  _your own configuration lines_
+#  """
+##
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+    -   id: codespell
+        additional_dependencies:
+          - tomli
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  codespell_extra_lines = """
+#  _your own configuration lines_
+#  """
+##
+-   repo: https://github.com/mgedmin/check-manifest
+    rev: "0.49"
+    hooks:
+    -   id: check-manifest
+-   repo: https://github.com/regebro/pyroma
+    rev: "4.2"
+    hooks:
+    -   id: pyroma
+-   repo: https://github.com/mgedmin/check-python-versions
+    rev: "0.21.2"
+    hooks:
+    -   id: check-python-versions
+        args: ['--only', 'setup.py,pyproject.toml']
+-   repo: https://github.com/collective/i18ndude
+    rev: "6.0.0"
+    hooks:
+    -   id: i18ndude
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pre_commit]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/config/default/packages.txt
+++ b/config/default/packages.txt
@@ -94,3 +94,4 @@ Products.MimetypesRegistry
 Products.PlonePAS
 Products.PortalTransforms
 Products.statusmessages
+meta

--- a/news/cfffba8c.internal
+++ b/news/cfffba8c.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,157 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+# See the inline comments on how to expand/tweak this configuration file
+[tool.towncrier]
+directory = "news/"
+filename = "CHANGES.rst"
+title_format = "{version} ({project_date})"
+underlines = ["-", ""]
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Breaking changes:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "feature"
+name = "New features:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "bugfix"
+name = "Bug fixes:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "internal"
+name = "Internal:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "documentation"
+name = "Documentation:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "tests"
+name = "Tests"
+showcontent = true
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  towncrier_extra_lines = """
+#  extra_configuration
+#  """
+##
+
+[tool.isort]
+profile = "plone"
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  isort_extra_lines = """
+#  extra_configuration
+#  """
+##
+
+[tool.black]
+target-version = ["py38"]
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  black_extra_lines = """
+#  extra_configuration
+#  """
+##
+
+[tool.codespell]
+ignore-words-list = "discreet,"
+skip = "*.po,"
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  codespell_ignores = "foo,bar"
+#  codespell_skip = "*.po,*.map,package-lock.json"
+##
+
+[tool.dependencychecker]
+Zope = [
+  # Zope own provided namespaces
+  'App', 'OFS', 'Products.Five', 'Products.OFSP', 'Products.PageTemplates',
+  'Products.SiteAccess', 'Shared', 'Testing', 'ZPublisher', 'ZTUtils',
+  'Zope2', 'webdav', 'zmi',
+  # ExtensionClass own provided namespaces
+  'ExtensionClass', 'ComputedAttribute', 'MethodObject',
+  # Zope dependencies
+  'AccessControl', 'Acquisition', 'AuthEncoding', 'beautifulsoup4', 'BTrees',
+  'cffi', 'Chameleon', 'DateTime', 'DocumentTemplate',
+  'MultiMapping', 'multipart', 'PasteDeploy', 'Persistence', 'persistent',
+  'pycparser', 'python-gettext', 'pytz', 'RestrictedPython', 'roman',
+  'soupsieve', 'transaction', 'waitress', 'WebOb', 'WebTest', 'WSGIProxy2',
+  'z3c.pt', 'zc.lockfile', 'ZConfig', 'zExceptions', 'ZODB', 'zodbpickle',
+  'zope.annotation', 'zope.browser', 'zope.browsermenu', 'zope.browserpage',
+  'zope.browserresource', 'zope.cachedescriptors', 'zope.component',
+  'zope.configuration', 'zope.container', 'zope.contentprovider',
+  'zope.contenttype', 'zope.datetime', 'zope.deferredimport',
+  'zope.deprecation', 'zope.dottedname', 'zope.event', 'zope.exceptions',
+  'zope.filerepresentation', 'zope.globalrequest', 'zope.hookable',
+  'zope.i18n', 'zope.i18nmessageid', 'zope.interface', 'zope.lifecycleevent',
+  'zope.location', 'zope.pagetemplate', 'zope.processlifetime', 'zope.proxy',
+  'zope.ptresource', 'zope.publisher', 'zope.schema', 'zope.security',
+  'zope.sequencesort', 'zope.site', 'zope.size', 'zope.structuredtext',
+  'zope.tal', 'zope.tales', 'zope.testbrowser', 'zope.testing',
+  'zope.traversing', 'zope.viewlet'
+]
+'Products.CMFCore' = [
+  'docutils', 'five.localsitemanager', 'Missing', 'Products.BTreeFolder2',
+  'Products.GenericSetup', 'Products.MailHost', 'Products.PythonScripts',
+  'Products.StandardCacheManagers', 'Products.ZCatalog', 'Record',
+  'zope.sendmail', 'Zope'
+]
+'plone.base' = [
+  'plone.batching', 'plone.registry', 'plone.schema','plone.z3cform',
+  'Products.CMFCore', 'Products.CMFDynamicViewFTI',
+]
+python-dateutil = ['dateutil']
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  dependencies_ignores = "['zestreleaser.towncrier']"
+#  dependencies_mappings = [
+#    "gitpython = ['git']",
+#    "pygithub = ['github']",
+#  ]
+#  """
+##
+
+[tool.check-manifest]
+ignore = [
+    ".editorconfig",
+    ".meta.toml",
+    ".pre-commit-config.yaml",
+    "tox.ini",
+    ".flake8",
+    "mx.ini",
+
+]
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  check_manifest_ignores = """
+#      "*.map.js",
+#      "*.pyc",
+#  """
+##
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [pyproject]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,189 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+# See the inline comments on how to expand/tweak this configuration file
+[tox]
+# We need 4.4.0 for constrain_package_deps.
+min_version = 4.4.0
+envlist =
+    lint
+    test
+    dependencies
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  envlist_lines = """
+#      my_other_environment
+#  """
+#  config_lines = """
+#  my_extra_top_level_tox_configuration_lines
+#  """
+##
+
+[testenv]
+skip_install = true
+allowlist_externals =
+    echo
+    false
+# Make sure typos like `tox -e formaat` are caught instead of silently doing nothing.
+# See https://github.com/tox-dev/tox/issues/2858.
+commands =
+    echo "Unrecognized environment name {envname}"
+    false
+
+[testenv:format]
+description = automatically reformat code
+skip_install = true
+deps =
+    pre-commit
+commands =
+    pre-commit run -a pyupgrade
+    pre-commit run -a isort
+    pre-commit run -a black
+    pre-commit run -a zpretty
+
+[testenv:lint]
+description = run linters that will help improve the code style
+skip_install = true
+deps =
+    pre-commit
+commands =
+    pre-commit run -a
+
+[testenv:dependencies]
+description = check if the package defines all its dependencies
+skip_install = true
+deps =
+    build
+    z3c.dependencychecker==2.11
+commands =
+    python -m build --sdist --no-isolation
+    dependencychecker
+
+[testenv:dependencies-graph]
+description = generate a graph out of the dependencies of the package
+skip_install = false
+allowlist_externals =
+    sh
+deps =
+    pipdeptree==2.5.1
+    graphviz  # optional dependency of pipdeptree
+commands =
+    sh -c 'pipdeptree --exclude setuptools,wheel,pipdeptree,zope.interface,zope.component --graph-output svg > dependencies.svg'
+
+[testenv:test]
+description = run the distribution tests
+use_develop = true
+skip_install = false
+constrain_package_deps = true
+set_env =
+    ROBOT_BROWSER=headlesschrome
+
+##
+# Specify extra test environment variables in .meta.toml:
+#  [tox]
+#  test_environment_variables = """
+#      PIP_EXTRA_INDEX_URL=https://my-pypi.my-server.com/
+#  """
+##
+deps =
+    zope.testrunner
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+##
+# Specify a custom constraints file in .meta.toml:
+#  [tox]
+#  constraints_file = "https://my-server.com/constraints.txt"
+##
+commands =
+    zope-testrunner --all --test-path={toxinidir} -s meta {posargs}
+extras =
+    test
+
+##
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  test_extras = """
+#      tests
+#      widgets
+#  """
+##
+
+[testenv:coverage]
+description = get a test coverage report
+use_develop = true
+skip_install = false
+constrain_package_deps = true
+set_env =
+    ROBOT_BROWSER=headlesschrome
+
+##
+# Specify extra test environment variables in .meta.toml:
+#  [tox]
+#  test_environment_variables = """
+#      PIP_EXTRA_INDEX_URL=https://my-pypi.my-server.com/
+#  """
+##
+deps =
+    coverage
+    zope.testrunner
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    coverage run --branch --source meta {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir} -s meta {posargs}
+    coverage report -m --format markdown
+    coverage xml
+extras =
+    test
+
+
+[testenv:release-check]
+description = ensure that the distribution is ready to release
+skip_install = true
+deps =
+    twine
+    build
+    towncrier
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    # fake version to not have to install the package
+    # we build the change log as news entries might break
+    # the README that is displayed on PyPI
+    towncrier build --version=100.0.0 --yes
+    python -m build --sdist --no-isolation
+    twine check dist/*
+
+[testenv:circular]
+description = ensure there are no cyclic dependencies
+use_develop = true
+skip_install = false
+set_env =
+
+##
+# Specify extra test environment variables in .meta.toml:
+#  [tox]
+#  test_environment_variables = """
+#      PIP_EXTRA_INDEX_URL=https://my-pypi.my-server.com/
+#  """
+##
+allowlist_externals =
+    sh
+deps =
+    pipdeptree
+    pipforester
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    # Generate the full dependency tree
+    sh -c 'pipdeptree -j > forest.json'
+    # Generate a DOT graph with the circular dependencies, if any
+    pipforester -i forest.json -o forest.dot --cycles
+    # Report if there are any circular dependencies, i.e. error if there are any
+    pipforester -i forest.json --check-cycles -o /dev/null
+
+
+##
+# Add extra configuration options in .meta.toml:
+#  [tox]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##


### PR DESCRIPTION
Apply `./config-package.py ../../meta/`.

This is mostly to get the towncrier config initialized.
I think plone/meta should have a changelog.
But the generated tests config doestn't make sense, so let's discuss if applying meta's own config-package on itself is a good idea...