### PR TITLE
Allow setting gha environment variables

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -151,6 +151,18 @@ ref = "master"
 In the previous example, all GitHub workflows would come from
 the `master` branch, instead of the default `main` branch.
 
+To set environment variables to be used by all jobs,
+specify the following key:
+
+```toml
+[github]
+env = """
+  debug: 1
+  image-name: 'org/image'
+  image-tag: 'latest'
+"""
+```
+
 To install specific OS level dependencies,
 note that they have to be Ubuntu package names, specify the following key:
 

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -368,6 +368,7 @@ class PackageConfiguration:
         options = self._get_options_for(
             'github',
             (
+                'env',
                 'ref',
                 'jobs',
                 'os_dependencies',
@@ -383,7 +384,6 @@ class PackageConfiguration:
             destination=destination,
             **options
         )
-        return self.copy_with_meta('meta.yml.j2', destination=destination)
 
     def gitlab_ci(self):
         if not self.is_gitlab:

--- a/config/default/meta.yml.j2
+++ b/config/default/meta.yml.j2
@@ -10,6 +10,21 @@ on:
       - main
   workflow_dispatch:
 
+{% if env %}
+env:
+%(env)s
+{% else %}
+##
+# To set environment variables for all jobs, add in .meta.toml:
+# [github]
+# env = """
+#     debug: 1
+#     image-name: 'org/image'
+#     image-tag: 'latest'
+# """
+##
+{% endif %}
+
 jobs:
 {% for job_name in jobs %}
   %(job_name)s:

--- a/news/164.feature
+++ b/news/164.feature
@@ -1,0 +1,1 @@
+Allow setting gha environment variables [@ericof]


### PR DESCRIPTION
To set environment variables to be used by all jobs,
specify the following key:

```toml
[github]
env = """
  debug: 1
  image-name: 'org/image'
  image-tag: 'latest'
"""
```