### PR TITLE
fix: adjust editorconfig for prettier

### DIFF
--- a/config/default/editorconfig.j2
+++ b/config/default/editorconfig.j2
@@ -33,6 +33,7 @@ indent_size = 2
 [*.{json,jsonl,js,jsx,ts,tsx,css,less,scss,html}]  # Frontend development
 # 2 space indentation
 indent_size = 2
+max_line_length = 80
 
 [{Makefile,.gitmodules}]
 # Tab indentation (no size specified, but view as 4 spaces)

--- a/news/1.bugfix
+++ b/news/1.bugfix
@@ -1,0 +1,2 @@
+Ensure that `prettier`'s default line length is respected.
+[@gforcada]


### PR DESCRIPTION
When using `prettier` to format JS code within a repository that has also been configured with `plone/meta`, the line length is turned off (global setting in this editorconfig file) and prettier follows that, thus concatenating lots of strings, that up until before, where following `prettier` default: 80 characters.