### PR TITLE
Playwright tests

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -459,6 +459,9 @@ test_environment_variables = """
 """
 ```
 
+For packages that have `plone.app.robotframework` based tests,
+it automatically detects it and primes `playwright` to install the needed browsers.
+
 ## Detailed script usage
 
 As said above, the `config-package.py` script is the tool to apply the configuration.

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -352,6 +352,8 @@ class PackageConfiguration:
         options['package_name'] = self.path.name
         options["news_folder_exists"] = (self.path / 'news').exists()
 
+        options['prime_robotframework'] = self._detect_robotframework()
+
         if not options['constrain_package_deps']:
             options['constrain_package_deps'] = "false"  if use_mxdev else "true"
         if not options['constraints_file']:
@@ -362,6 +364,23 @@ class PackageConfiguration:
             'tox.ini.j2',
             **options
         )
+
+    def _detect_robotframework(self):
+        """Dynamically find out if robotframework is used in the package.
+
+        We look at the dependencies, as we expect the depenedency checker
+        to make it easy for us.
+        """
+        try_files = (
+            self.path / 'setup.py',
+            self.path / 'pyproject.toml',
+        )
+        for file_obj in try_files:
+            if file_obj.exists():
+                text = file_obj.read_text()
+                if 'plone.app.robotframework' in text:
+                    return True
+        return False
 
     def news_entry(self):
         news = self.path / 'news'

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -123,6 +123,9 @@ deps =
 #  constraints_file = "https://my-server.com/constraints.txt"
 ##
 commands =
+{% if prime_robotframework %}
+    rfbrowser init
+{% endif %}
     pytest --disable-warnings {posargs} {toxinidir}%(test_path)s
 extras =
     test
@@ -154,6 +157,9 @@ deps =
     -c %(constraints_file)s
     %(test_deps_additional)s
 commands =
+{% if prime_robotframework %}
+    rfbrowser init
+{% endif %}
     coverage run --source %(package_name)s -m pytest  {posargs} --disable-warnings {toxinidir}%(test_path)s
     coverage report -m --format markdown
     coverage xml
@@ -194,6 +200,9 @@ deps =
 #  constraints_file = "https://my-server.com/constraints.txt"
 ##
 commands =
+{% if prime_robotframework %}
+    rfbrowser init
+{% endif %}
     zope-testrunner --all --test-path={toxinidir}%(test_path)s -s %(package_name)s {posargs}
 extras =
     test
@@ -228,6 +237,9 @@ deps =
     -c %(constraints_file)s
     %(test_deps_additional)s
 commands =
+{% if prime_robotframework %}
+    rfbrowser init
+{% endif %}
     coverage run --branch --source %(package_name)s {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir}%(test_path)s -s %(package_name)s {posargs}
     coverage report -m --format markdown
     coverage xml

--- a/news/155.feature
+++ b/news/155.feature
@@ -1,0 +1,3 @@
+Install browsers (for playwright) on packages that run
+plone.app.robotframework tests.
+[gforcada]


### PR DESCRIPTION
Closes #155 

Rather than a setting that needs to be set up on `.meta.toml` we try to detect if the package needs it.

Hopefully the package uses the dependency checker tool, and thus, the dependency on `plone.app.robotframework` can be easily spotted ✨ 