### PR TITLE
In pyproject.toml, add build-system requiring setuptools 68.2+.

### DIFF
--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.2", "wheel"]
+requires = ["setuptools>=68.2"]
 
 {% if news_folder_exists %}
 [tool.towncrier]

--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -1,3 +1,6 @@
+[build-system]
+requires = ["setuptools>=68.2", "wheel"]
+
 {% if news_folder_exists %}
 [tool.towncrier]
 directory = "news/"

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -71,7 +71,7 @@ deps =
     build
     z3c.dependencychecker==2.11
 commands =
-    python -m build --sdist --no-isolation
+    python -m build --sdist
     dependencychecker
 
 [testenv:dependencies-graph]
@@ -266,7 +266,7 @@ commands =
     # the README that is displayed on PyPI
     towncrier build --version=100.0.0 --yes
 {% endif %}
-    python -m build --sdist --no-isolation
+    python -m build --sdist
     twine check dist/*
 
 [testenv:circular]

--- a/news/172.feature
+++ b/news/172.feature
@@ -1,0 +1,5 @@
+In generated ``pyproject.toml`` files, add ``build-system`` requiring ``setuptools`` 68.2+.
+Also, build the package in isolation, so the build is free to use the required ``setuptools`` version.
+This combination fixes possible ``ModuleNotFoundErrors`` for ``plone.app.*`` packages.
+See `issue 172 <https://github.com/plone/meta/issues/172>`_.
+[maurits]


### PR DESCRIPTION
Also, build the package in isolation, so the build is free to use the required `setuptools` version. This combination fixes possible `ModuleNotFoundErrors` for `plone.app.*` packages. See https://github.com/plone/meta/issues/172