### PR TITLE
Always run all formatting steps

### DIFF
--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -55,6 +55,8 @@ commands =
 
 [testenv:format]
 description = automatically reformat code
+ignore_errors = true
+ignore_outcome = true
 skip_install = true
 deps =
     pre-commit

--- a/news/188.feature
+++ b/news/188.feature
@@ -1,0 +1,1 @@
+Add `ignore_errors` and `ignore_outcome` to `[testenv:format]` in tox to always run all formatting steps [@ericof]


### PR DESCRIPTION
Add `ignore_errors` and `ignore_outcome` to `[testenv:format]` in tox to always run all formatting steps

Fixes #188 