### PR TITLE
Release distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ _custom configuration_
 
 #### `tox.ini`
 
+##### Testing
+
 Depending on the test runner that you want to use, `plone.meta` will adapt `tox.ini` to it.
 
 In the `[tox]` TOML table in `.meta.toml`, set the value for the key `test_runner` to `pytest` if you want to use [`pytest`](https://pypi.org/project/pytest).
@@ -434,6 +436,23 @@ Likewise, the root path where the tests are to be found can be specified under t
 By default, it is set to nothing, that is, the repository's top level is already importable and thus the tests can be found directly.
 
 If either a `tests` or `src` folder exists, then they are used as safe fallbacks.
+
+##### Environments
+
+`plone/meta` generates the following `tox` environments:
+
+- `init`: prepares the environment (only if `mxdev` is used)
+- `test`: runs the package's python tests
+- `coverage`: runs the package's python tests and generates a coverage report out of it
+- `dependencies`: checks that all python dependencies are specified properly
+- `dependencies-graph`: generates a graph to visualize the dependencies tree/forest
+- `circular`: checks that within the dependency graph there are no circular imports
+- `release-check`: runs a few sanity checks to know if the distribution is ready to be released
+- `release`: releases a new version of the distribution
+- `format`: runs python/HTML/XML code formatters on the source code
+- `lint`: runs quite some python linters
+
+##### Options
 
 Add the `[tox]` TOML table in `.meta.toml`, and set the extra configuration for `tox` under the `extra_lines` key.
 

--- a/src/plone/meta/default/tox.ini.j2
+++ b/src/plone/meta/default/tox.ini.j2
@@ -43,3 +43,12 @@ envlist =
 #  _your own configuration lines_
 #  """
 ##
+
+[testenv:release]
+description = create a new release
+skip_install = true
+deps =
+    zest.release[recommended]
+    -c %(constraints_file)s
+commands =
+    fullrelease


### PR DESCRIPTION
Partially is #100 but it does simply install and call `fullrelease` from `zest.releaser`.

This way, it all still happens locally... from a security point of view, maybe that's best? Otherwise any random developer can do:

```shell
git clone https://github.com/plone/plone.batching
cd plone.batching
tox -e release
```

💥 

Do we want that? 🤔 

If we only call `fullrelease` on `tox -e release` if you don't have upload permissions on PyPI the release is not uploaded. 🩹 

This together with the https://github.com/plone/meta/issues/187 it will create both releases on PyPI but also on GitHub 🎉 

And if we expand mr.roboto(?) to monitor releases in GitHub, we can map new Plone distributions' releases with in which Plone version they are used (i.e. `plone.batching` new release should be added to both Plone `6.0` and `6.1`).

At the end that would be to (partially) merge `plone.releaser` to `mr.roboto`.

@mauritsvanrees not sure how comfortable you would be with this change, and if that makes sense at all 🤔 

The grand idea behind all this stepping stones is to distribute the load to create new releases while at the same time keep all those new versions finding their way to the right Plone version.

I'm thinking about refactoring code, for example, one needs to wait for the other distribution to be released with the code that has been moved there, to be able to depend on it.

If a new release on the first distribution finds its way on the `plone-6xx-dev.txt` requirements file, then we can depend on these files being updated automatically upon a new release.

@davisagli @jensens @ericof (and others of course!) opinions? Probably we should move this to community.plone.org?