### PR TITLE
Editorconfig: Restructure the frontend config.

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -100,6 +100,16 @@ _your own configuration lines_
 """
 ```
 
+If you want to set the indentation for frontend related files to 4 spaces add the following to your `.meta.toml`:
+
+```toml
+[editorconfig]
+extra_lines = """
+[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss}]
+indent_size = 4
+"""
+```
+
 ### `.flake8`
 
 Add the `[flake8]` TOML table in `.meta.toml`,

--- a/config/default/editorconfig.j2
+++ b/config/default/editorconfig.j2
@@ -26,11 +26,11 @@ max_line_length = off
 # 4 space indentation
 indent_size = 4
 
-[*.{yml,zpt,pt,dtml,zcml}]
+[*.{yml,zpt,pt,dtml,zcml,html,xml}]
 # 2 space indentation
 indent_size = 2
 
-[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss,html}]  # Frontend development
+[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss}]  # Frontend development
 # 2 space indentation
 indent_size = 2
 max_line_length = 80

--- a/news/197.internal
+++ b/news/197.internal
@@ -1,0 +1,11 @@
+Editorconfig: Restructure the frontend config.
+
+- Add an xml type to the xml section.
+- Move the HTML type to the xml section.
+
+This allows more easily for frontend related files except HTML files to be
+reconfigured for an 4-space indentation. 4 spaces for JS/CSS related code is
+the default style in Patternslib/Mockup. style.
+
+Fixes: #197
+[thet]


### PR DESCRIPTION
- Add an xml type to the xml section.
- Move the HTML type to the xml section.

This allows more easily for frontend related files except HTML files to be
reconfigured for an 4-space indentation. 4 spaces for JS/CSS related code is
the default style in Patternslib/Mockup. style.

Fixes: #197