### PR TITLE
Moved comments in .editorconfig to their own lines

### DIFF
--- a/config/default/editorconfig.j2
+++ b/config/default/editorconfig.j2
@@ -10,7 +10,8 @@
 root = true
 
 
-[*]  # For All Files
+[*]
+# Default settings for all files.
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 insert_final_newline = true
@@ -30,7 +31,8 @@ indent_size = 4
 # 2 space indentation
 indent_size = 2
 
-[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss}]  # Frontend development
+[*.{json,jsonl,js,jsx,ts,tsx,css,less,scss}]
+# Frontend development
 # 2 space indentation
 indent_size = 2
 max_line_length = 80

--- a/news/208.bugfix
+++ b/news/208.bugfix
@@ -1,0 +1,3 @@
+Moved inline comments in .editorconfig to their own lines: the spec at
+https://spec.editorconfig.org/#no-inline-comments forbids it.
+[reinout]


### PR DESCRIPTION
Reason: https://spec.editorconfig.org/#no-inline-comments
Fixes #207 