### PR TITLE
Deprecate old GHA workflows

### DIFF
--- a/news/+cleanup.bugfix
+++ b/news/+cleanup.bugfix
@@ -1,0 +1,2 @@
+Mark old `shared-workflows` GHA as deprecated.
+[gforcada]

--- a/shared-workflows/tests.yml
+++ b/shared-workflows/tests.yml
@@ -14,25 +14,11 @@ jobs:
   test:
     name: Run tests
     runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: ${{ fromJSON(vars.TEST_PYTHON_VERSIONS) }}
-        os: ${{ fromJSON(vars.TEST_OS_VERSIONS) }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Cache packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: python -m pip install tox
-      - name: Run tests
-        run: tox -e test
+      - name: 'Deprecation warning'
+        run: |
+          echo "This GHA is deprecated, please re-run plone/meta on your repository"
+          echo "If you are still relying on this jobs, "
+          echo "please create an issue in https://github.com/plone/meta/issues/new"
+          exit 1


### PR DESCRIPTION
This `shared-workflows` folder was used when the idea was to use GitHub organization wide workflows, but the idea turned out not to be so great, nor useful outside the GitHub Plone organization.

They were left there, so, before deleting them, let's make them crash, to see if there is anyone out there still using them, hopefully not 🤞🏾 