### PR TITLE
Avoid using global variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ${{ fromJSON(vars.TEST_PYTHON_VERSIONS) }}
-        os: ${{ fromJSON(vars.TEST_OS_VERSIONS) }}
+        python-version: ["3.11"]
+        os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/news/210.bugfix
+++ b/news/210.bugfix
@@ -1,0 +1,2 @@
+Stop relying on GitHub repository/organization variables
+[gforcada]


### PR DESCRIPTION
Avoid depending on `vars.*` variables defined at GitHub repository or organization level to run the test job.
    
We need a way to define which python and OS combinations each repository wants to use, but not defined in a global way, that by default, is broken for everyone that is not in Plone GitHub organization.

