### PR TITLE
Junit reports

### DIFF
--- a/config/default/gitlab-ci.yml.j2
+++ b/config/default/gitlab-ci.yml.j2
@@ -73,7 +73,13 @@ testing:
   script:
 %(os_dependencies)s
     - pip install tox
-    - tox -e test
+    - tox -e test -- --xml reports
+  artifacts:
+      when: always
+      reports:
+        junit:
+          - reports/testreports/*.xml
+
 ##
 # Add extra test/coverage commands in .meta.toml:
 #  [gitlab]

--- a/config/default/gitlab-ci.yml.j2
+++ b/config/default/gitlab-ci.yml.j2
@@ -110,6 +110,7 @@ coverage:
       coverage_report:
         coverage_format: cobertura
         path: coverage.xml
+  coverage: '/TOTAL.* \*\*(\d+)\%\*\*/'
   except:
     - schedules
 {% endif %}

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -251,6 +251,7 @@ commands =
     coverage run --branch --source %(package_name)s {envbindir}/zope-testrunner --quiet --all --test-path={toxinidir}%(test_path)s -s %(package_name)s {posargs}
     coverage report -m --format markdown
     coverage xml
+    coverage html
 extras =
     test
 %(test_extras)s


### PR DESCRIPTION
When using GitLab, report the tests that did run.

As a bonus, report also the coverage percentage to GitLab so it can be used on the UI.

We need a counterpart for those for GitHub, but we can still get this merged, and as time/need allows, get those as well.

There has to be some GHA that gets a junit report and there's plenty regarding coverage as well.