### PR TITLE
feat(gitlab): cache pre-commit directory

### DIFF
--- a/config/default/gitlab-ci.yml.j2
+++ b/config/default/gitlab-ci.yml.j2
@@ -28,6 +28,11 @@ stages:
 {% if "lint" in jobs %}
 lint:
   stage: qa
+  variables:
+    PRE_COMMIT_HOME: ${CI_PROJECT_DIR}/.cache/pre-commit
+  cache:
+    paths:
+      - ${PRE_COMMIT_HOME}
   script:
     - pip install tox
     - tox -e lint


### PR DESCRIPTION
This way, it will reuse the hooks installed

See https://pre-commit.com/#managing-ci-caches