### PR TITLE
No track by default

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -536,7 +536,7 @@ __Tip:__ Use `current` to update the current branch.
 
 `--tox`: whether to run `tox` on the repository. By default it is not run.
 
-`--no-track`: whether the package being configured should _not_ be added on `defaults/packages.txt`. By default, packages' names are added to it.
+`--track`: whether the package being configured should be added on `defaults/packages.txt`. By default, they are _not_ added.
 
 The following options are only needed one time
 as their values are stored in `.meta.toml.`.

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -104,10 +104,10 @@ def handle_command_line_arguments():
         'If not given it is constructed automatically and includes '
         'the configuration type. Use "current" to update the current branch.')
     parser.add_argument(
-        '--no-track',
+        '--track',
         dest='track_package',
-        action='store_false',
-        default=True,
+        action='store_true',
+        default=False,
         help='Whether to add the package being configured in packages.txt.')
 
     args = parser.parse_args()

--- a/news/+ignore2.bugfix
+++ b/news/+ignore2.bugfix
@@ -1,0 +1,1 @@
+Do not track packages on `packages.txt` by default @gforcada


### PR DESCRIPTION
On the original `zopefoundation/meta` they had this option as `True` by default, as the idea is to ensure that whenever major changes (new python version, etc) are applied to a template folder (here in `plone/meta` only `config/default`) all repositories listed in `packages.txt` would be updated.

Here in `plone/meta` we departed from that idea and instead we use this tool as a generic configuration tool for any repository. It is not only meant for plone packages only.

Thus, it does not make sense to track packages by default.