### PR TITLE
check-manifest: ignore dependabot.yml.

### DIFF
--- a/config/default/pyproject.toml.j2
+++ b/config/default/pyproject.toml.j2
@@ -150,11 +150,12 @@ ignore-packages = %(dependencies_ignores)s
 [tool.check-manifest]
 ignore = [
     ".editorconfig",
+    ".flake8",
     ".meta.toml",
     ".pre-commit-config.yaml",
-    "tox.ini",
-    ".flake8",
+    "dependabot.yml",
     "mx.ini",
+    "tox.ini",
 %(check_manifest_ignores)s
 ]
 %(check_manifest_extra_lines)s

--- a/news/201.feature
+++ b/news/201.feature
@@ -1,1 +1,1 @@
-Configure `dependabot` to get GHA updates @gforcada
+Configure `dependabot` to get GHA updates. @gforcada


### PR DESCRIPTION
Needed after a recent PR.
And manually sort the lines there.