### PR TITLE
Circular env: always constrain package deps.

### DIFF
--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -284,6 +284,9 @@ commands =
 description = ensure there are no cyclic dependencies
 use_develop = true
 skip_install = false
+# Here we must always constrain the package deps to what is already installed,
+# otherwise we simply get the latest from PyPI, which may not work.
+constrain_package_deps = true
 set_env =
 %(test_environment_variables)s
 ##


### PR DESCRIPTION
Otherwise you get the latest packages from PyPI.
Currently this means you get `plone.app.multilingual` 8 which is meant for Plone 6.1, and `Products.CMFPlone` 6.0.10.  These depend on each other so you get an error.

Note that in other places in `tox.ini` we already use `constrain_package_deps = true`.  But we set this to false when using `mxdev`.  I did not try to understand if that makes sense.  But at least for the `circular` env this would be wrong.

Tested:

* `plone.edu` (which uses `mxdev`) depends on `plone.app.multilingual` and its circular check failed.
* I locally edited `plone.app.users` to depend on `plone.app.multilingual` and that one failed as well.

This PR fixes it.

I will let two PRs or comments link to this PR that use it.