### PR TITLE
GHA: run tests with multiple python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,14 +9,18 @@ on:
       os-packages:
         required: false
         type: string
+      py-versions:
+        required: false
+        default: '["3.11", "3.10", "3.9", "3.8"]'
+        type: string
 
 jobs:
   test:
-    name: Tests report
+    name: Plone 6.0 / py${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ${{ fromJson( inputs.py-versions) }}
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
         type: string
       py-versions:
         required: false
-        default: '["3.11", "3.10", "3.9", "3.8"]'
+        default: '["3.12", "3.10"]'
         type: string
 
 jobs:

--- a/config/README.md
+++ b/config/README.md
@@ -204,6 +204,18 @@ note that they have to be Ubuntu package names, specify the following key:
 os_dependencies = "git libxml2"
 ```
 
+To run tests against specific python versions,
+specify the following key:
+
+Note: the GHA expects a string to be parsed as a JSON array.
+
+Note 2: unfortunately, quotes need to be escaped :-/
+
+```toml
+[github]
+py_versions = "[\"3.11\", \"3.10\"]"
+```
+
 Extend github workflow configuration with additional jobs
 by setting the values for the `extra_lines` key.
 

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -429,6 +429,7 @@ class PackageConfiguration:
                 'ref',
                 'jobs',
                 'os_dependencies',
+                'py_versions',
                 'extra_lines',
             )
         )

--- a/config/default/meta.yml.j2
+++ b/config/default/meta.yml.j2
@@ -29,9 +29,16 @@ jobs:
 {% for job_name in jobs %}
   %(job_name)s:
     uses: plone/meta/.github/workflows/%(job_name)s.yml@%(ref)s
-  {% if job_name in ('test', 'coverage') and os_dependencies %}
+  {% if job_name == 'test' and (os_dependencies or py_versions) %}
     with:
-        os-packages: '%(os_dependencies)s'
+{% if os_dependencies %}       os-packages: '%(os_dependencies)s'{% endif %}
+
+{% if py_versions %}       py-versions: '%(py_versions)s'{% endif %}
+
+  {% endif %}
+  {% if job_name == 'coverage' and os_dependencies %}
+    with:
+       os-packages: '%(os_dependencies)s'
   {% endif %}
 {% endfor %}
 
@@ -53,6 +60,13 @@ jobs:
 # when running tests/coverage jobs, add in .meta.toml:
 # [github]
 # os_dependencies = "git libxml2 libxslt"
+##
+
+##
+# To test against a specific matrix of python versions
+# when running tests jobs, add in .meta.toml:
+# [github]
+# py_versions = "['3.12', '3.11']"
 ##
 
 %(extra_lines)s

--- a/news/210.feature
+++ b/news/210.feature
@@ -1,0 +1,1 @@
+GHA: Allow to run `tox -e test` with multiple python versions @gforcada


### PR DESCRIPTION
Part of #210 

Runs tests for a given package with any list of python packages provided by the package itself, or, with the defaults provided by the workflow defined here in `plone/meta`.

This is only 1 of the 3 axis mentioned in #210 (OS / Plone / python), though probably the most important and the easiest 😅 

@1letter