### PR TITLE
By default do not test on 3.12.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
         type: string
       py-versions:
         required: false
-        default: '["3.12", "3.10"]'
+        default: '["3.11", "3.10"]'
         type: string
 
 jobs:


### PR DESCRIPTION
Packages that use gocept.pytestlayer are broken then, because it is not compatible. It is being replaced by zope.pytestlayer.
Sample error:
https://github.com/plone/plone.releaser/actions/runs/9086068912/job/24970903122 ModuleNotFoundError: No module named 'imp'