### PR TITLE
Tox: Allow explicitly setting the package_name

### DIFF
--- a/config/config-package.py
+++ b/config/config-package.py
@@ -361,7 +361,7 @@ class PackageConfiguration:
         )
         use_mxdev = options.get("use_mxdev", False)
         options.update(self._test_cfg())
-        package_name = options.get("package_name", self.path.name)
+        options["package_name"] = options.get("package_name") or self.path.name
         options["news_folder_exists"] = (self.path / 'news').exists()
 
         options['prime_robotframework'] = self._detect_robotframework()

--- a/config/config-package.py
+++ b/config/config-package.py
@@ -356,11 +356,12 @@ class PackageConfiguration:
                 'test_environment_variables',
                 'extra_lines',
                 'use_pytest_plone',
+                'package_name'
             )
         )
         use_mxdev = options.get("use_mxdev", False)
         options.update(self._test_cfg())
-        options['package_name'] = self.path.name
+        package_name = options.get("package_name", self.path.name)
         options["news_folder_exists"] = (self.path / 'news').exists()
 
         options['prime_robotframework'] = self._detect_robotframework()

--- a/config/default/tox.ini.j2
+++ b/config/default/tox.ini.j2
@@ -158,6 +158,13 @@ set_env =
 # Set constrain_package_deps .meta.toml:
 #  [tox]
 #  constrain_package_deps = "false"
+#
+# Explicitly set the package name .meta.toml:
+#  (For cases where the repository name is not the same of
+#   the package name)
+#  [tox]
+#  package_name = "pytest_plone"
+#
 ##
 deps =
 {% if use_pytest_plone %}    pytest-plone


### PR DESCRIPTION
For cases where the folder name is distinct from the package_name (i.e.: pytest-plone / pytest_plone)