### PR TITLE
Ignore files forest.dot and forest.json

### DIFF
--- a/config/default/gitignore.j2
+++ b/config/default/gitignore.j2
@@ -17,6 +17,8 @@ __pycache__/
 .tox
 .vscode/
 node_modules/
+forest.dot
+forest.json
 
 # venv / buildout related
 bin/


### PR DESCRIPTION
These files are generated when we run `tox -e circular`