### PR TITLE
Switch to use tox-uv

### DIFF
--- a/.github/workflows/circular.yml
+++ b/.github/workflows/circular.yml
@@ -16,25 +16,20 @@ jobs:
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Install uv + caching
+        uses: astral-sh/setup-uv@v7.5.0
         with:
+          enable-cache: true
+          cache-dependency-glob: |
+            setup.*
+            tox.ini
+            pyproject.toml
           python-version: ${{ matrix.python-version }}
-      - name: Cache packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
       - name: Install OS dependencies
         run: sudo apt-get install -y libgraphviz-dev
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Initialize tox
         run: |
-          if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
+          if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi
       - name: Run circular dependencies check
         run: |
-          tox -e circular
+          uvx --with tox-uv tox -e circular

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,26 +20,21 @@ jobs:
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Install uv + caching
+        uses: astral-sh/setup-uv@v7.5.0
         with:
+          enable-cache: true
+          cache-dependency-glob: |
+            setup.*
+            tox.ini
+            pyproject.toml
           python-version: ${{ matrix.python-version }}
       - name: install OS packages
         if: inputs.os-packages != ''
         run: sudo apt-get install -y ${{ inputs.os-packages }}
-      - name: Cache packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Initialize tox
         run: |
-          if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
+          if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi
       - name: Run coverage
         run: |
-          tox -q -e coverage >> $GITHUB_STEP_SUMMARY
+          uvx --with tox-uv tox -e coverage >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,23 +16,18 @@ jobs:
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Install uv + caching
+        uses: astral-sh/setup-uv@v7.5.0
         with:
+          enable-cache: true
+          cache-dependency-glob: |
+            setup.*
+            tox.ini
+            pyproject.toml
           python-version: ${{ matrix.python-version }}
-      - name: Cache packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Initialize tox
         run: |
-          if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
+          if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi
       - name: Run dependencies
         run: |
-          tox -e dependencies
+          uvx --with tox-uv tox -e dependencies

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -10,22 +10,16 @@ jobs:
         python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Install uv + caching
+        uses: astral-sh/setup-uv@v7.5.0
         with:
+          enable-cache: true
+          cache-dependency-glob: |
+            tox.ini
+            pyproject.toml
           python-version: ${{ matrix.python-version }}
-      - name: Cache packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Run QA tools
-        run: tox -e lint
+        run: uvx tox -e lint
 
   test:
     name: Tests / py${{ matrix.python-version }}
@@ -35,22 +29,16 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Install uv + caching
+        uses: astral-sh/setup-uv@v7.5.0
         with:
+          enable-cache: true
+          cache-dependency-glob: |
+            tox.ini
+            pyproject.toml
           python-version: ${{ matrix.python-version }}
-      - name: Cache packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Run tests
-        run: tox -e test
+        run: uvx tox -e test
 
   coverage:
     name: Coverage
@@ -60,19 +48,13 @@ jobs:
         python-version: ["3.13"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Install uv + caching
+        uses: astral-sh/setup-uv@v7.5.0
         with:
+          enable-cache: true
+          cache-dependency-glob: |
+            tox.ini
+            pyproject.toml
           python-version: ${{ matrix.python-version }}
-      - name: Cache packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Run tests
-        run: tox -e coverage
+        run: uvx tox -e coverage

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -16,23 +16,18 @@ jobs:
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Install uv + caching
+        uses: astral-sh/setup-uv@v7.5.0
         with:
+          enable-cache: true
+          cache-dependency-glob: |
+            setup.*
+            tox.ini
+            pyproject.toml
           python-version: ${{ matrix.python-version }}
-      - name: Cache packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Initialize tox
         run: |
-          if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
+          if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi
       - name: Run QA tools
         run: |
-          tox -e lint
+          uvx --with tox-uv tox -e lint

--- a/.github/workflows/release_ready.yml
+++ b/.github/workflows/release_ready.yml
@@ -16,23 +16,18 @@ jobs:
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Install uv + caching
+        uses: astral-sh/setup-uv@v7.5.0
         with:
+          enable-cache: true
+          cache-dependency-glob: |
+            setup.*
+            tox.ini
+            pyproject.toml
           python-version: ${{ matrix.python-version }}
-      - name: Cache packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('tox.ini') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ matrix.python-version }}-
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: python -m pip install tox
       - name: Initialize tox
         run: |
-          if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
+          if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi
       - name: Check release status
         run: |
-          tox -e release-check
+          uvx --with tox-uv tox -e release-check

--- a/news/246.feature
+++ b/news/246.feature
@@ -1,0 +1,1 @@
+Switch GHA workflows used by projects configured with `plone.meta` to `tox-uv` to speed them up @gforcada

--- a/src/plone/meta/default/gitlab-ci.yml.j2
+++ b/src/plone/meta/default/gitlab-ci.yml.j2
@@ -34,7 +34,7 @@ lint:
     paths:
       - ${PRE_COMMIT_HOME}
   script:
-    - pip install tox
+    - pip install tox-uv
     - tox -e lint
   except:
     - schedules
@@ -44,7 +44,7 @@ lint:
 release-ready:
   stage: qa
   script:
-    - pip install tox
+    - pip install tox-uv
     - tox -e release-check
   except:
     - schedules
@@ -54,7 +54,7 @@ release-ready:
 dependencies:
   stage: qa
   script:
-    - pip install tox
+    - pip install tox-uv
     - tox -e dependencies
   except:
     - schedules
@@ -66,7 +66,7 @@ circular-dependencies:
   script:
     - apt-get update
     - apt-get install -y graphviz graphviz-dev
-    - pip install tox
+    - pip install tox-uv
     - tox -e circular
   except:
     - schedules
@@ -78,7 +78,7 @@ testing:
   image: $DOCKER_IMAGE
   script:
 %(os_dependencies)s
-    - pip install tox
+    - pip install tox-uv
     - tox -e $TOX_ENV -- --xml reports
   parallel:
     matrix:
@@ -108,7 +108,7 @@ coverage:
   stage: test
   script:
 %(os_dependencies)s
-    - pip install tox
+    - pip install tox-uv
     - tox -e coverage
 ##
 # Add extra test/coverage commands in .meta.toml:

--- a/src/plone/meta/default/test-matrix.yml.j2
+++ b/src/plone/meta/default/test-matrix.yml.j2
@@ -26,11 +26,15 @@ jobs:
     - uses: actions/checkout@v6
       with:
         persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v6
+    - name: Install uv + caching
+      uses: astral-sh/setup-uv@v7.5.0
       with:
+        enable-cache: true
+        cache-dependency-glob: |
+          setup.*
+          tox.ini
+          pyproject.toml
         python-version: ${{ matrix.config[0] }}
-        allow-prereleases: true
 {% if os_dependencies %}
     - name: install OS packages
       run: sudo apt-get install -y %(os_dependencies)s
@@ -43,25 +47,13 @@ jobs:
 #  _your own configuration lines_
 #  """
 ##
-    - name: Pip cache
-      uses: actions/cache@v5
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
     - name: Initialize tox
       # the bash one-liner below does not work on Windows
       if: contains(matrix.os, 'ubuntu')
       run: |
-        if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
+        if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi
     - name: Test
-      run: tox -e ${{ matrix.config[2] }}
+      run: uvx --with tox-uv tox -e ${{ matrix.config[2] }}
 
 %(extra_lines)s
 ##


### PR DESCRIPTION
Part of #246 

Use `tox-uv` for:

- `plone.meta` own CI workflows (i.e. `local.yml`)
- for the `test-matrix.yml` workflow that gets installed on all repositories configured with `plone.meta`, see it on https://github.com/plone/plone.batching/pull/109
- the shared workflows used by `plone.meta` configured repositories
- on the GitLab CI jobs (for repositories that use that)