### PR TITLE
Use package version

### DIFF
--- a/news/248.bugfix
+++ b/news/248.bugfix
@@ -1,0 +1,2 @@
+On `.meta.toml` file installed by `plone.meta`, write `plone.meta`'s version on `commit-id` rather than a commit.
+We are no longer running `plone.meta` out of a checkout, but rather from a release version @gforcada

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -1,10 +1,10 @@
 from .shared.call import call
 from .shared.git import get_branch_name
-from .shared.git import get_commit_id
 from .shared.git import git_branch
 from .shared.git import git_server_url
 from .shared.path import change_dir
 from functools import cached_property
+from importlib.metadata import version
 
 import argparse
 import collections
@@ -134,7 +134,7 @@ class PackageConfiguration:
 
         self.meta_cfg = self._read_meta_configuration()
         self.meta_cfg["meta"]["template"] = self.config_type
-        self.meta_cfg["meta"]["commit-id"] = get_commit_id()
+        self.meta_cfg["meta"]["commit-id"] = self._get_version()
 
         with change_dir(self.path):
             server_url = git_server_url()
@@ -145,6 +145,9 @@ class PackageConfiguration:
                 "CI configuration",
                 "The repository is not hosted in github nor in gitlab, no CI configuration will be done!",
             )
+
+    def _get_version(self):
+        return version("plone.meta")
 
     def _read_meta_configuration(self):
         """Read and update meta configuration"""


### PR DESCRIPTION
Part of #248 

If we are not meant to use a git checkout but an actual version, record that on `.meta.toml` when configuring/updating repositories.

It needs #250 to get merged first