### PR TITLE
fix(gha/gitlab): ensure listings are always sorted

### DIFF
--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -531,7 +531,9 @@ class PackageConfiguration:
         combinations = []
         for plone_version, python_versions in test_matrix.items():
             no_dot_plone = plone_version.replace(".", "")
-            for py_version in {python_versions[0], python_versions[-1]}:
+            top_bottom_versions = {python_versions[0], python_versions[-1]}
+            sorted_versions = sorted(top_bottom_versions, reverse=True)
+            for py_version in sorted_versions:
                 no_dot_python = py_version.replace(".", "")
                 combinations.append(
                     f'["{py_version}", "{plone_version} on py{py_version}", "py{no_dot_python}-plone{no_dot_plone}"]'
@@ -563,7 +565,9 @@ class PackageConfiguration:
         image = ""
         for plone_version, python_versions in test_matrix.items():
             no_dot_plone = plone_version.replace(".", "")
-            for py_version in {python_versions[0], python_versions[-1]}:
+            top_bottom_versions = {python_versions[0], python_versions[-1]}
+            sorted_versions = sorted(top_bottom_versions, reverse=True)
+            for py_version in sorted_versions:
                 no_dot_python = py_version.replace(".", "")
                 image = DOCKER_IMAGES.get(py_version)
                 if custom_images:


### PR DESCRIPTION
As @davisagli already pointed out, order is not stable when you iterate over a set (see #262 ).

It's not too much of a problem, the functional result is the same, but it generates extra noise when applying `plone.meta` twice on the same repository 😓 