### PR TITLE
Restrict `setuptools` to 75.8.0 as maximum when building a package.

### DIFF
--- a/news/267.bugfix
+++ b/news/267.bugfix
@@ -1,0 +1,5 @@
+Restrict `setuptools` to 75.8.0 as maximum when building a package.
+Require `wheel` as well in the `build-system`.
+Explicitly set the build backend to use `setuptools`.
+See also [pep 517](https://peps.python.org/pep-0517/) and [pep 518](https://peps.python.org/pep-0518/).
+[maurits]

--- a/news/267.bugfix
+++ b/news/267.bugfix
@@ -1,5 +1,4 @@
 Restrict `setuptools` to 75.8.0 as maximum when building a package.
 Require `wheel` as well in the `build-system`.
-Explicitly set the build backend to use `setuptools`.
 See also [pep 517](https://peps.python.org/pep-0517/) and [pep 518](https://peps.python.org/pep-0518/).
 [maurits]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools < 74"]
+requires = ["setuptools>=68.2,<=75.8.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [build-system]
 requires = ["setuptools>=68.2,<=75.8.0", "wheel"]
+# We must set a build-backend, because the default build-backend needs a setup.py.
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "plone.meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = ["setuptools>=68.2,<=75.8.0", "wheel"]
-build-backend = "setuptools.build_meta"
 
 [project]
 name = "plone.meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.2,<=75.8.0", "wheel"]
+requires = ["setuptools>=68.2", "wheel"]
 # We must set a build-backend, because the default build-backend needs a setup.py.
 build-backend = "setuptools.build_meta"
 

--- a/src/plone/meta/default/pyproject.toml.j2
+++ b/src/plone/meta/default/pyproject.toml.j2
@@ -1,6 +1,5 @@
 [build-system]
 requires = ["setuptools>=68.2,<=75.8.0", "wheel"]
-build-backend = "setuptools.build_meta"
 
 {% if news_folder_exists %}
 [tool.towncrier]

--- a/src/plone/meta/default/pyproject.toml.j2
+++ b/src/plone/meta/default/pyproject.toml.j2
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools>=68.2"]
+requires = ["setuptools>=68.2,<=75.8.0", "wheel"]
+build-backend = "setuptools.build_meta"
 
 {% if news_folder_exists %}
 [tool.towncrier]


### PR DESCRIPTION
Require `wheel` as well in the `build-system`.
Explicitly set the build backend to use `setuptools`.

See also [pep 517](https://peps.python.org/pep-0517/) and [pep 518](https://peps.python.org/pep-0518/).

Fixes https://github.com/plone/meta/issues/267

Used in https://github.com/plone/plone.app.caching/pull/148