### PR TITLE
Fix towncrier config to use Tests: with a colon.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,27 +64,32 @@ issue_format = "[#{issue}](https://github.com/plone/meta/issues/{issue})"
 
 [[tool.towncrier.type]]
 directory = "breaking"
-name = "Breaking changes"
+name = "Breaking changes:"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "feature"
-name = "New features"
+name = "New features:"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "bugfix"
-name = "Bug fixes"
+name = "Bug fixes:"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "internal"
-name = "Internal"
+name = "Internal:"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "documentation"
-name = "Documentation"
+name = "Documentation:"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "tests"
+name = "Tests:"
 showcontent = true
 
 [tool.isort]

--- a/src/plone/meta/default/pyproject.toml.j2
+++ b/src/plone/meta/default/pyproject.toml.j2
@@ -47,7 +47,7 @@ showcontent = true
 
 [[tool.towncrier.type]]
 directory = "tests"
-name = "Tests"
+name = "Tests:"
 showcontent = true
 %(towncrier_extra_lines)s
 {% endif %}


### PR DESCRIPTION
All the other news snippet categories already had a colon at the end of their name.

Copy this part of the template to our own `pyproject.toml` as well: this gives us colons as well, and adds `tests` as category.