### PR TITLE
run `tox -e init` if available

### DIFF
--- a/src/plone/meta/default/test-matrix.yml.j2
+++ b/src/plone/meta/default/test-matrix.yml.j2
@@ -46,5 +46,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tox
+    - name: Initialize tox
+      # the bash one-liner below does not work on Windows
+      if: contains(matrix.os, 'ubuntu')
+      run: |
+        if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
     - name: Test
       run: tox -e ${{ matrix.config[2] }}

--- a/src/plone/meta/default/tox-test-coverage.j2
+++ b/src/plone/meta/default/tox-test-coverage.j2
@@ -7,6 +7,7 @@ set_env = {[base]set_env}
 deps =
     {[test_runner]deps}
     %(single_constraints_file)s
+    %(test_deps_additional)s
 commands = {[test_runner]test}
 extras = {[base]extras}
 %(testenv_options)s
@@ -32,6 +33,7 @@ deps =
     {[test_runner]deps}
     coverage
     %(single_constraints_file)s
+    %(test_deps_additional)s
 commands = {[test_runner]coverage}
 extras = {[base]extras}
 %(testenv_options)s


### PR DESCRIPTION
took this from the former shared test.yml https://github.com/plone/meta/blob/2.x/.github/workflows/test.yml#L48 