### PR TITLE
Accept setuptools < 80.

### DIFF
--- a/news/267.bugfix
+++ b/news/267.bugfix
@@ -1,4 +1,4 @@
-Restrict `setuptools` to 75.8.0 as maximum when building a package.
+Restrict `setuptools` to less than 80 when building a package.
 Require `wheel` as well in the `build-system`.
 See also [pep 517](https://peps.python.org/pep-0517/) and [pep 518](https://peps.python.org/pep-0518/).
 [maurits]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # This is the pyproject.toml of plone.meta itself, *not* of generated projects.
 
 [build-system]
-requires = ["setuptools>=68.2,<77", "wheel"]
+requires = ["setuptools>=68.2,<80", "wheel"]
 # We must set a build-backend, because the default build-backend needs a setup.py.
 build-backend = "setuptools.build_meta"
 

--- a/src/plone/meta/default/pyproject.toml.j2
+++ b/src/plone/meta/default/pyproject.toml.j2
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.2,<77", "wheel"]
+requires = ["setuptools>=68.2,<80", "wheel"]
 
 {% if news_folder_exists %}
 [tool.towncrier]


### PR DESCRIPTION
We were restricting to less than 77, but higher seems fine now. There are too many changes in setuptools 80 though which may not work for all packages.
