### PR TITLE
Support github options extra_lines/extra_lines_after_os_dependencies

### DIFF
--- a/news/+3ed635f4.feature.md
+++ b/news/+3ed635f4.feature.md
@@ -1,0 +1,2 @@
+Support github options `extra_lines` and `extra_lines_after_os_dependencies`.
+[maurits]

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -546,6 +546,7 @@ class PackageConfiguration:
                 "jobs",
                 "os_dependencies",
                 "extra_lines",
+                "extra_lines_after_os_dependencies",
             ),
         )
         if not options.get("ref"):

--- a/src/plone/meta/default/test-matrix.yml.j2
+++ b/src/plone/meta/default/test-matrix.yml.j2
@@ -34,6 +34,14 @@ jobs:
     - name: install OS packages
       run: sudo apt-get install -y %(os_dependencies)s
 {% endif %}
+%(extra_lines_after_os_dependencies)s
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines_after_os_dependencies = """
+#  _your own configuration lines_
+#  """
+##
     - name: Pip cache
       uses: actions/cache@v4
       with:
@@ -53,3 +61,12 @@ jobs:
         if [ `tox list --no-desc -f init|wc -l` = 1 ]; then tox -e init;else true; fi
     - name: Test
       run: tox -e ${{ matrix.config[2] }}
+
+%(extra_lines)s
+##
+# Add extra configuration options in .meta.toml:
+#  [github]
+#  extra_lines = """
+#  _your own configuration lines_
+#  """
+##


### PR DESCRIPTION
`extra_lines` was already passed on to the test matrix, but not used. `extra_lines_after_os_dependencies` is needed for `Products.CMFPlone` to configure a locale, needed for one test.

This is needed in CMFPlone, otherwise you get a few [test failures](https://github.com/plone/Products.CMFPlone/actions/runs/17646723151/job/50146492222#step:7:158):

```
ValueError: Unsupported locale.
These tests need at least one of the following locales available on your system:
('en_US.ISO-8859-1', 'en_US.ISO8859-15', 'en_GB.ISO8859-15',
'de_DE@euro', 'fr_FR@euro', 'nl_NL@euro')
```

I use this in the [CMFPlone src-layout PR](https://github.com/plone/Products.CMFPlone/pull/4218), in [this commit](https://github.com/plone/Products.CMFPlone/pull/4218/commits/52d0c2aaba870e95817df30d606bdeacf5addcbd).  And the try to fix it in this [second commit](https://github.com/plone/Products.CMFPlone/pull/4218/commits/e2a15f7b05113e49b7c8b3a3f241d23b0f09c204). And that seems to help.