### PR TITLE
Do not add `test_deps_additional` to all tox envs

### DIFF
--- a/news/293.bugfix.md
+++ b/news/293.bugfix.md
@@ -1,0 +1,2 @@
+Do not add `test_deps_additional` to `circular` and `release-check` tox envs.
+@mauritsvanrees

--- a/src/plone/meta/default/tox-plone-depending-qa.j2
+++ b/src/plone/meta/default/tox-plone-depending-qa.j2
@@ -8,7 +8,6 @@ deps =
     towncrier
 {% endif %}
     %(single_constraints_file)s
-    %(test_deps_additional)s
 commands =
 {% if news_folder_exists %}
     # fake version to not have to install the package
@@ -41,7 +40,6 @@ deps =
     pipdeptree
     pipforester
     %(single_constraints_file)s
-    %(test_deps_additional)s
 commands =
     # Generate the full dependency tree
     sh -c 'pipdeptree -j > forest.json'


### PR DESCRIPTION
It break the `circular` env and it is not needed for `release-check`. Only `test` and `coverage` (and derived python-plone-specific envs) need it.

Fixes https://github.com/plone/meta/issues/293

