### PR TITLE
Script: switch to PEP 420 native namespace

### DIFF
--- a/news/3982.feature.md
+++ b/news/3982.feature.md
@@ -1,0 +1,1 @@
+Add and adapt switch-to-pep420 script from zope meta.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ Documentation = "https://6.docs.plone.org/developer-guide/standardize-python-pro
 config-package = "plone.meta.config_package:main"
 multi-call = "plone.meta.multi_call:main"
 re-enable-actions = "plone.meta.re_enable_actions:main"
+switch-to-pep420 = "plone.meta.pep_420:main"
 
 [tool.towncrier]
 directory = "news/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
   "tomlkit",
   "tox",
   "validate-pyproject[all]",
+  "zest.releaser",
 ]
 
 [project.urls]

--- a/src/plone/meta/pep_420.py
+++ b/src/plone/meta/pep_420.py
@@ -11,13 +11,13 @@
 # FOR A PARTICULAR PURPOSE.
 #
 ##############################################################################
-import argparse
-import pathlib
-import shutil
-
 from .shared.call import call
 from .shared.git import git_branch
 from .shared.path import change_dir
+
+import argparse
+import pathlib
+import shutil
 
 
 def main():
@@ -51,19 +51,18 @@ def main():
         "--no-commit, changes will not be committed and pushed automatically.",
     )
     parser.add_argument(
-        '--no-tests',
-        dest='run_tests',
-        action='store_false',
+        "--no-tests",
+        dest="run_tests",
+        action="store_false",
         default=True,
-        help='Skip running unit tests.',
+        help="Skip running unit tests.",
     )
 
     args = parser.parse_args()
     path = args.path.absolute()
 
     if not (path / ".git").exists():
-        raise ValueError(
-            "`path` does not point to a git clone of a repository!")
+        raise ValueError("`path` does not point to a git clone of a repository!")
     if not (path / ".meta.toml").exists():
         raise ValueError("The repository `path` points to has no .meta.toml!")
 
@@ -82,8 +81,7 @@ def main():
         call(bin_dir / "bumpversion", "--breaking", *non_interactive_params)
         call(
             bin_dir / "addchangelogentry",
-            "Replace ``pkg_resources`` namespace with PEP 420"
-            " native namespace."
+            "Replace ``pkg_resources`` namespace with PEP 420 native namespace.",
         )
 
         setup_py = []
@@ -135,8 +133,8 @@ def main():
                 print("Updated the previously created PR.")
             else:
                 print(
-                    "Are you logged in via `gh auth login` to create a PR?"
-                    " (y/N)?", end=" ",
+                    "Are you logged in via `gh auth login` to create a PR? (y/N)?",
+                    end=" ",
                 )
                 if input().lower() == "y":
                     call(

--- a/src/plone/meta/pep_420.py
+++ b/src/plone/meta/pep_420.py
@@ -36,6 +36,13 @@ def main():
         " type",
     )
     parser.add_argument(
+        "--no-breaking",
+        dest="breaking",
+        action="store_false",
+        default=True,
+        help="Don't bump for breaking change. Use this if release is already alpha.",
+    )
+    parser.add_argument(
         "--no-commit",
         dest="commit",
         action="store_false",
@@ -85,7 +92,8 @@ def main():
         else:
             args.commit = False
 
-        call(bin_dir / "bumpversion", "--breaking", *non_interactive_params)
+        if args.breaking:
+            call(bin_dir / "bumpversion", "--breaking", *non_interactive_params)
         call(
             bin_dir / "addchangelogentry",
             "Replace ``pkg_resources`` namespace with PEP 420 native namespace.",

--- a/src/plone/meta/pep_420.py
+++ b/src/plone/meta/pep_420.py
@@ -82,7 +82,7 @@ def main():
 
     with change_dir(path) as cwd_str:
         cwd = pathlib.Path(cwd_str)
-        bin_dir = cwd / "bin"
+        bin_dir = cwd / "venv" / "bin"
         branch_name = args.branch_name or "pep-420-native-namespace"
         updating = git_branch(branch_name)
 
@@ -136,7 +136,7 @@ def main():
             call("git", "add", ".")
 
         if args.run_tests:
-            tox_path = shutil.which("tox") or (cwd / "bin" / "tox")
+            tox_path = shutil.which("tox") or (cwd / "venv" / "bin" / "tox")
             call(tox_path, "-p", "auto")
 
         if args.commit:

--- a/src/plone/meta/pep_420.py
+++ b/src/plone/meta/pep_420.py
@@ -94,9 +94,8 @@ def main():
 
         if args.breaking:
             call(bin_dir / "bumpversion", "--breaking", *non_interactive_params)
-        call(
-            bin_dir / "addchangelogentry",
-            "Replace ``pkg_resources`` namespace with PEP 420 native namespace.",
+        (path / "news" / "3928.breaking").write_text(
+            "Replace ``pkg_resources`` namespace with PEP 420 native namespace.\n"
         )
 
         setup_py = []

--- a/src/plone/meta/pep_420.py
+++ b/src/plone/meta/pep_420.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+##############################################################################
+#
+# Copyright (c) 2025 Zope Foundation and Contributors.
+#
+# This software is subject to the provisions of the Zope Public License,
+# Version 2.1 (ZPL).  A copy of the ZPL should accompany this distribution.
+# THIS SOFTWARE IS PROVIDED "AS IS" AND ANY AND ALL EXPRESS OR IMPLIED
+# WARRANTIES ARE DISCLAIMED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF TITLE, MERCHANTABILITY, AGAINST INFRINGEMENT, AND FITNESS
+# FOR A PARTICULAR PURPOSE.
+#
+##############################################################################
+import argparse
+import pathlib
+import shutil
+
+from .shared.call import call
+from .shared.git import git_branch
+from .shared.path import change_dir
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Update a repository to PEP 420 native namespace."
+    )
+    parser.add_argument(
+        "path", type=pathlib.Path, help="path to the repository to be updated"
+    )
+    parser.add_argument(
+        "--branch",
+        dest="branch_name",
+        default=None,
+        help="Define a git branch name to be used for the changes. If not"
+        " given it is constructed automatically and includes the configuration"
+        " type",
+    )
+    parser.add_argument(
+        "--no-commit",
+        dest="commit",
+        action="store_false",
+        default=True,
+        help='Don\'t "git commit" changes made by this script.',
+    )
+    parser.add_argument(
+        "--interactive",
+        dest="interactive",
+        action="store_true",
+        default=False,
+        help="Run interactively: Scripts will prompt for input. Implies "
+        "--no-commit, changes will not be committed and pushed automatically.",
+    )
+    parser.add_argument(
+        '--no-tests',
+        dest='run_tests',
+        action='store_false',
+        default=True,
+        help='Skip running unit tests.',
+    )
+
+    args = parser.parse_args()
+    path = args.path.absolute()
+
+    if not (path / ".git").exists():
+        raise ValueError(
+            "`path` does not point to a git clone of a repository!")
+    if not (path / ".meta.toml").exists():
+        raise ValueError("The repository `path` points to has no .meta.toml!")
+
+    with change_dir(path) as cwd_str:
+        cwd = pathlib.Path(cwd_str)
+        bin_dir = cwd / "bin"
+        branch_name = args.branch_name or "pep-420-native-namespace"
+        updating = git_branch(branch_name)
+
+        non_interactive_params = []
+        if not args.interactive and args.commit:
+            non_interactive_params = ["--no-input"]
+        else:
+            args.commit = False
+
+        call(bin_dir / "bumpversion", "--breaking", *non_interactive_params)
+        call(
+            bin_dir / "addchangelogentry",
+            "Replace ``pkg_resources`` namespace with PEP 420"
+            " native namespace."
+        )
+
+        setup_py = []
+        for line in (path / "setup.py").read_text().splitlines():
+            if "from setuptools import find_packages" in line:
+                continue
+            elif "namespace_packages" in line:
+                continue
+            elif "packages=" in line:
+                continue
+            elif "package_dir=" in line:
+                continue
+            elif "zope.testrunner" in line:
+                setup_py.append(
+                    line.replace("zope.testrunner", "zope.testrunner >= 6.4")
+                )
+            else:
+                setup_py.append(line)
+
+        (path / "setup.py").write_text("\n".join(setup_py) + "\n")
+
+        for src_dir_cont in (path / "src").iterdir():
+            if not src_dir_cont.is_dir():
+                continue
+            pkg_init = src_dir_cont / "__init__.py"
+            if pkg_init.exists():
+                pkg_init.unlink()
+            for pkg_dir_cont in src_dir_cont.iterdir():
+                if not pkg_dir_cont.is_dir():
+                    continue
+                sub_pkg_init = pkg_dir_cont / "__init__.py"
+                if sub_pkg_init.exists():
+                    if "pkg_resources" in sub_pkg_init.read_text():
+                        sub_pkg_init.unlink()
+
+        if args.commit:
+            print("Adding all changes ...")
+            call("git", "add", ".")
+
+        if args.run_tests:
+            tox_path = shutil.which("tox") or (cwd / "bin" / "tox")
+            call(tox_path, "-p", "auto")
+
+        if args.commit:
+            print("Committing and pushing all changes ...")
+            call("git", "commit", "-m", "Switch to PEP 420 native namespace.")
+            call("git", "push", "--set-upstream", "origin", branch_name)
+            if updating:
+                print("Updated the previously created PR.")
+            else:
+                print(
+                    "Are you logged in via `gh auth login` to create a PR?"
+                    " (y/N)?", end=" ",
+                )
+                if input().lower() == "y":
+                    call(
+                        "gh",
+                        "pr",
+                        "create",
+                        "--fill",
+                        "--title",
+                        "Switch to PEP 420 native namespace.",
+                    )
+                else:
+                    print("If everything went fine up to here:")
+                    print("Create a PR, using the URL shown above.")
+        else:
+            print("Applied all changes. Please check and commit manually.")

--- a/src/plone/meta/pep_420.py
+++ b/src/plone/meta/pep_420.py
@@ -100,7 +100,9 @@ def main():
         )
 
         setup_py = []
-        for line in (path / "setup.py").read_text().splitlines():
+        setup_text = (path / "setup.py").read_text()
+        has_62_classifier = "Framework :: Plone :: 6.2" in setup_text
+        for line in setup_text.splitlines():
             if "from setuptools import find_packages" in line:
                 continue
             elif "namespace_packages" in line:
@@ -131,6 +133,15 @@ def main():
                 )
             else:
                 setup_py.append(line)
+                # One extra check after the line has been added.
+                if (
+                    not has_62_classifier
+                    and "Framework :: Plone" in line
+                    and "Framework :: Plone ::" not in line
+                ):
+                    setup_py.append(
+                        line.replace("Framework :: Plone", "Framework :: Plone :: 6.2")
+                    )
 
         (path / "setup.py").write_text("\n".join(setup_py) + "\n")
 

--- a/src/plone/meta/pep_420.py
+++ b/src/plone/meta/pep_420.py
@@ -43,6 +43,13 @@ def main():
         help='Don\'t "git commit" changes made by this script.',
     )
     parser.add_argument(
+        "--push",
+        dest="push",
+        action="store_true",
+        default=False,
+        help="Push changes directly.",
+    )
+    parser.add_argument(
         "--interactive",
         dest="interactive",
         action="store_true",
@@ -126,8 +133,11 @@ def main():
             call(tox_path, "-p", "auto")
 
         if args.commit:
-            print("Committing and pushing all changes ...")
+            print("Committing all changes ...")
             call("git", "commit", "-m", "Switch to PEP 420 native namespace.")
+            if not args.push:
+                print("All changes committed. Please check and push manually.")
+                return
             call("git", "push", "--set-upstream", "origin", branch_name)
             if updating:
                 print("Updated the previously created PR.")

--- a/src/plone/meta/pep_420.py
+++ b/src/plone/meta/pep_420.py
@@ -96,6 +96,7 @@ def main():
             call(bin_dir / "bumpversion", "--breaking", *non_interactive_params)
         (path / "news" / "3928.breaking").write_text(
             "Replace ``pkg_resources`` namespace with PEP 420 native namespace.\n"
+            "Support only Plone 6.2 and Python 3.10+.\n"
         )
 
         setup_py = []
@@ -111,6 +112,22 @@ def main():
             elif "zope.testrunner" in line:
                 setup_py.append(
                     line.replace("zope.testrunner", "zope.testrunner >= 6.4")
+                )
+            elif "Framework :: Plone :: 6.0" in line:
+                continue
+            elif "Framework :: Plone :: 6.1" in line:
+                continue
+            elif "Programming Language :: Python :: 3.8" in line:
+                continue
+            elif "Programming Language :: Python :: 3.9" in line:
+                continue
+            elif 'python_requires=">=3.8"' in line:
+                setup_py.append(
+                    line.replace('python_requires=">=3.8"', 'python_requires=">=3.10"')
+                )
+            elif 'python_requires=">=3.9"' in line:
+                setup_py.append(
+                    line.replace('python_requires=">=3.9"', 'python_requires=">=3.10"')
                 )
             else:
                 setup_py.append(line)


### PR DESCRIPTION
I have copied the script from zope meta and adapted it a bit for our packages.
I have added `zest.releaser` as dependency, because the script call `bin/bumpversion`.

I have applied it on `plone.protect` like this, first making the package for Plone 6.2 only:

- `./venv/bin/config-package --branch pep-420-native-namespace /Users/maurits/community/plone-coredev/6.2/src/plone.protect`
- Edit `.meta.toml` and set:
-
  ```
  [tox]
  test_matrix = {"6.2" = ["*"]}
  ```
- `./venv/bin/config-package --branch pep-420-native-namespace --commit-msg "Set test matrix to 6.2 only." /Users/maurits/community/plone-coredev/6.2/src/plone.protect`
- `./venv/bin/switch-to-pep420 --no-breaking /Users/maurits/community/plone-coredev/6.2/src/plone.protect`

I have added `--no-breaking`, otherwise it wants to bump `6.0.0a2.dev0` to `7.0.0.dev0`.

For most other packages we would not use this option, because we *do* want a major release.  But then we first need to create an x.y maintenance branch, and change coredev 6.1 (and possibly 6.0) to use this branch in `sources.cfg`.

Resulting PR for `plone.protect` is here:
https://github.com/plone/plone.protect/pull/138