### PR TITLE
`switch-to-pep420` script: remove `setuptools` dependency.

### DIFF
--- a/news/3982.bugfix.md
+++ b/news/3982.bugfix.md
@@ -1,0 +1,1 @@
+`switch-to-pep420` script: remove `setuptools` dependency.  @mauritsvanrees

--- a/src/plone/meta/pep_420.py
+++ b/src/plone/meta/pep_420.py
@@ -104,6 +104,8 @@ def main():
         for line in setup_text.splitlines():
             if "from setuptools import find_packages" in line:
                 continue
+            elif '"setuptools",' in line:
+                continue
             elif "namespace_packages" in line:
                 continue
             elif "packages=" in line:


### PR DESCRIPTION
None of our packages should need `setuptools` in the `install_requires` anymore.  Let's remove it.