### PR TITLE
Update pre-commit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ ci:
 
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
@@ -12,8 +12,8 @@ repos:
     rev: 7.0.0
     hooks:
       - id: isort
-  - repo: https://github.com/psf/black
-    rev: 25.1.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 25.11.0
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/flake8

--- a/src/plone/meta/default/pre-commit-config.yaml.j2
+++ b/src/plone/meta/default/pre-commit-config.yaml.j2
@@ -4,7 +4,7 @@ ci:
 
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
@@ -13,7 +13,7 @@ repos:
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.9.0
+    rev: 25.11.0
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
@@ -63,12 +63,12 @@ repos:
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.23.0"
+    rev: "0.24.0"
     hooks:
     -   id: check-python-versions
         args: ['--only', 'setup.py,pyproject.toml']
 -   repo: https://github.com/collective/i18ndude
-    rev: "6.2.1"
+    rev: "6.3.0"
     hooks:
     -   id: i18ndude
 %(i18ndude_extra_lines)s


### PR DESCRIPTION
Also switched our own pre-commit config from `black` to `black-pre-commit-mirror` like we have in the template file.

Used in https://github.com/plone/borg.localrole/pull/38 in [this commit](https://github.com/plone/borg.localrole/pull/38/commits/b107d210a5b9c788e77b927f57438bf1bc61e5b2).