### PR TITLE
Update actions/cache from v4 to v5

### DIFF
--- a/src/plone/meta/default/test-matrix.yml.j2
+++ b/src/plone/meta/default/test-matrix.yml.j2
@@ -43,7 +43,7 @@ jobs:
 #  """
 ##
     - name: Pip cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}


### PR DESCRIPTION
As dependabot is currently doing on all repositories