### PR TITLE
pin setuptools to version < 82.0.0 in the tox-qa template

### DIFF
--- a/news/320.bugfix
+++ b/news/320.bugfix
@@ -1,0 +1,3 @@
+pin setuptools to version < 82.0.0 in the tox-qa template [testenv:dependencies]
+this fix `ModuleNotFoundError: No module named 'pkg_resources'` if run `tox -e dependencies` in a project
+z3c.dependencychecker is not ready for PEP 420 native namespace @1letter

--- a/src/plone/meta/default/tox-qa.j2
+++ b/src/plone/meta/default/tox-qa.j2
@@ -22,6 +22,7 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
+    setuptools<82.0.0
     z3c.dependencychecker==2.14.3
 commands =
     python -m build --sdist


### PR DESCRIPTION
pin setuptools to version < 82.0.0 in the tox-qa template [testenv:dependencies]

this fix `ModuleNotFoundError: No module named 'pkg_resources'` if run `tox -e dependencies` in a project, because z3c.dependencychecker is not ready for PEP 420 native namespace