### PR TITLE
Set constrain_package_deps to true when not explicitly set.

### DIFF
--- a/news/316.bugfix.md
+++ b/news/316.bugfix.md
@@ -1,0 +1,2 @@
+Set `constrain_package_deps` to true when not explicitly set, even when using `mxdev`.
+@mauritsvanrees

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -405,7 +405,6 @@ class PackageConfiguration:
                 "test_matrix",
             ),
         )
-        use_mxdev = options.get("use_mxdev", False)
         options.update(self._test_cfg())
         options["package_name"] = options.get("package_name") or self.path.name
         options["news_folder_exists"] = (self.path / "news").exists()
@@ -413,7 +412,12 @@ class PackageConfiguration:
         options["prime_robotframework"] = self._detect_robotframework()
 
         if not options["constrain_package_deps"]:
-            options["constrain_package_deps"] = "false" if use_mxdev else "true"
+            # We used to set constrain_package_deps to false when using mxdex.
+            # But this seems wrong, leading to completely ignoring the constraints.
+            # See https://github.com/plone/meta/issues/316
+            # and before that:
+            # https://github.com/plone/meta/pull/220
+            options["constrain_package_deps"] = "true"
 
         if options["use_pytest_plone"] is not False:
             # Default is '', so turn it into True


### PR DESCRIPTION
Do this also when using `mxdev`.
This fixes https://github.com/plone/meta/issues/316.

* In 2023 in https://github.com/plone/meta/pull/158 Erico added mxdev support, and it set `constrain_package_deps` to false if mxdev was used, see commit 7abb844574d5f84996728c5d5dac331cd695864b.
* In 2024 I [noticed a problem with this](https://github.com/plone/meta/pull/158#issuecomment-1988437040), at least in the `circular` tox env.
* So in https://github.com/plone/meta/pull/220 I set `constrain_package_deps = true` in the `circular` env.
* Then recently I discovered problems for this in the normal `test` tox env as well, described in https://github.com/plone/meta/issues/316.

So now I set `constrain_package_deps` to true when it is not explicitly set.

