### PR TITLE
Add option `use_test_matrix`, default true.

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,13 @@ test_matrix = { "6.1" = ["3.13", "3.10"], "6.0" = ["*"] }
 
 When the list of Python versions is `*`, `plone.meta` replaces it with the default Python version list for this Plone version.
 
+If a test matrix will not work for your project, you can disable the test matrix entirely:
+
+```toml
+[tox]
+use_test_matrix = false
+```
+
 Extend the list of default `tox` environments in the `envlist_lines` key.
 Add extra top level configuration for `tox` in the `config_lines` key.
 

--- a/news/+a335d1b5.feature.md
+++ b/news/+a335d1b5.feature.md
@@ -1,0 +1,2 @@
+Add option `use_test_matrix`, default true.
+When false, don't use the test matrix.

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -403,6 +403,7 @@ class PackageConfiguration:
                 "use_pytest_plone",
                 "package_name",
                 "test_matrix",
+                "use_test_matrix",
             ),
         )
         options.update(self._test_cfg())
@@ -424,14 +425,19 @@ class PackageConfiguration:
             options["use_pytest_plone"] = True
 
         options.update(self._handle_constraints_files(options))
-        options["plone_envlist_lines"] = self._handle_testing_matrix(
-            options["test_matrix"]
-        )
+        if options.get("use_test_matrix", True):
+            options["plone_envlist_lines"] = self._handle_testing_matrix(
+                options["test_matrix"]
+            )
+        else:
+            options["plone_envlist_lines"] = ""
         return self.copy_with_meta("tox.ini.j2", **options)
 
     def _handle_constraints_files(self, options):
         if options.get("use_mxdev", False):
             constraints = single_constraints = f"-c {MXDEV_CONSTRAINTS}"
+        elif not options.get("use_test_matrix", True):
+            constraints = single_constraints = ""
         else:
             constraints = options["constraints_files"]
             test_matrix = get_test_matrix(options.get("test_matrix"))
@@ -536,8 +542,9 @@ class PackageConfiguration:
         return destination.relative_to(self.path)
 
     def gha_workflows(self):
+        files = []
         if not self.is_github:
-            return []
+            return files
         github_folder = self.path / ".github"
         workflows_folder = github_folder / "workflows"
         workflows_folder.mkdir(parents=True, exist_ok=True)
@@ -560,9 +567,11 @@ class PackageConfiguration:
         meta_file = self.copy_with_meta(
             "meta.yml.j2", destination=destination, **options
         )
+        files.append(meta_file)
         dependabot = self.copy_with_meta(
             "dependabot.yml", destination=github_folder / "dependabot.yml"
         )
+        files.append(dependabot)
 
         if (self.path / "dependabot.yml").exists():
             self.print_warning(
@@ -570,19 +579,38 @@ class PackageConfiguration:
                 "A `dependabot.yml` file at the top-level was found, please remove it",
             )
 
-        options["gh_config_lines"] = self.handle_gh_actions()
-        testing_file = self.copy_with_meta(
-            "test-matrix.yml.j2",
-            destination=workflows_folder / "test-matrix.yml",
-            **options,
+        use_test_matrix = self._get_options_for("tox", ("use_test_matrix",)).get(
+            "use_test_matrix", True
         )
+        if use_test_matrix:
+            options["gh_config_lines"] = self.handle_gh_actions()
+            testing_file = self.copy_with_meta(
+                "test-matrix.yml.j2",
+                destination=workflows_folder / "test-matrix.yml",
+                **options,
+            )
+            files.append(testing_file)
+        elif (workflows_folder / "test-matrix.yml").exists():
+            self.print_warning(
+                "CI configuration",
+                "A `test-matrix.yml` file was found in the workflows folder, please remove it",
+            )
 
-        return [meta_file, dependabot, testing_file]
+        return files
 
     def handle_gh_actions(self):
-        options = self._get_options_for("tox", ("test_matrix",))
-        test_matrix = get_test_matrix(options.get("test_matrix"))
+        options = self._get_options_for(
+            "tox",
+            (
+                "test_matrix",
+                "use_test_matrix",
+            ),
+        )
         combinations = []
+        # By default we use the test matrix, but you can explicitly opt out.
+        if not options.get("use_test_matrix", True):
+            return combinations
+        test_matrix = get_test_matrix(options.get("test_matrix"))
         for plone_version, python_versions in test_matrix.items():
             no_dot_plone = plone_version.replace(".", "")
             # Only test the lowest and highest Python version for a given Plone
@@ -617,12 +645,28 @@ class PackageConfiguration:
         options["destination"] = self.path / ".gitlab-ci.yml"
         if not options.get("jobs"):
             options["jobs"] = GITLAB_DEFAULT_JOBS
+
+        use_test_matrix = self._get_options_for("tox", ("use_test_matrix",)).get(
+            "use_test_matrix", True
+        )
+        if not use_test_matrix and "testing" in options["jobs"]:
+            options["jobs"].remove("testing")
+
         return self.copy_with_meta("gitlab-ci.yml.j2", **options)
 
     def _gitlab_testing_matrix(self, custom_images):
-        options = self._get_options_for("tox", ("test_matrix",))
-        test_matrix = get_test_matrix(options.get("test_matrix"))
+        options = self._get_options_for(
+            "tox",
+            (
+                "test_matrix",
+                "use_test_matrix",
+            ),
+        )
         combinations = []
+        # By default we use the test matrix, but you can explicitly opt out.
+        if not options.get("use_test_matrix", True):
+            return combinations
+        test_matrix = get_test_matrix(options.get("test_matrix"))
         image = ""
         for plone_version, python_versions in test_matrix.items():
             no_dot_plone = plone_version.replace(".", "")
@@ -674,7 +718,7 @@ class PackageConfiguration:
 
         # Get rid of spaces on lines with only spaces, like happens in the generated
         # tox.ini
-        content = re.sub(r"\n\ +\n", r"\n\n", content)
+        content = re.sub(r" +\n", r"\n", content)
 
         # Get rid of empty lines at the end.
         content = content.strip() + "\n"

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -271,6 +271,12 @@ class PackageConfiguration:
         """Get all given named options from a given section"""
         options = {}
         for name in names:
+            # TODO We may want to define defaults somewhere, instead of
+            # passing an empty string as default here.  Especially for boolean
+            # options that should by default be True, like use_pytest_plone
+            # and use_test_matrix.  Currently we need to explicitly compare
+            # with False:
+            # if options["use_pytest_plone"] is not False:
             options[name] = self.cfg_option(section, name, "")
         return options
 
@@ -425,7 +431,9 @@ class PackageConfiguration:
             options["use_pytest_plone"] = True
 
         options.update(self._handle_constraints_files(options))
-        if options.get("use_test_matrix", True):
+        if options["use_test_matrix"] is not False:
+            # Default is '', so turn it into True
+            options["use_test_matrix"] = True
             options["plone_envlist_lines"] = self._handle_testing_matrix(
                 options["test_matrix"]
             )
@@ -436,7 +444,10 @@ class PackageConfiguration:
     def _handle_constraints_files(self, options):
         if options.get("use_mxdev", False):
             constraints = single_constraints = f"-c {MXDEV_CONSTRAINTS}"
-        elif not options.get("use_test_matrix", True):
+        elif options["use_test_matrix"] is False:
+            # Default value is '', which we interpret as True.
+            # TODO This is confusing, we may need to define the defaults
+            # somewhere.  See also '_get_options_for'.
             constraints = single_constraints = ""
         else:
             constraints = options["constraints_files"]
@@ -608,7 +619,7 @@ class PackageConfiguration:
         )
         combinations = []
         # By default we use the test matrix, but you can explicitly opt out.
-        if not options.get("use_test_matrix", True):
+        if options["use_test_matrix"] is False:
             return combinations
         test_matrix = get_test_matrix(options.get("test_matrix"))
         for plone_version, python_versions in test_matrix.items():
@@ -664,7 +675,7 @@ class PackageConfiguration:
         )
         combinations = []
         # By default we use the test matrix, but you can explicitly opt out.
-        if not options.get("use_test_matrix", True):
+        if options["use_test_matrix"] is False:
             return combinations
         test_matrix = get_test_matrix(options.get("test_matrix"))
         image = ""

--- a/src/plone/meta/default/tox.ini.j2
+++ b/src/plone/meta/default/tox.ini.j2
@@ -12,6 +12,7 @@ envlist =
 # Add extra configuration options in .meta.toml:
 # - to specify a custom testing combination of Plone and python versions, use `test_matrix`
 #   Use ["*"] to use all supported Python versions for this Plone version.
+# - to disable the test matrix entirely, set `use_test_matrix = false`
 # - to specify extra custom environments, use `envlist_lines`
 # - to specify extra `tox` top-level options, use `config_lines`
 #  [tox]


### PR DESCRIPTION
When false, don't use the test matrix.
I use this option in https://github.com/plone/plone.autoinclude/pull/46 in [this commit](https://github.com/plone/plone.autoinclude/commit/f825429a04ba060a9209ed7447f5e5429993f605). See failing tests at https://github.com/plone/plone.autoinclude/actions/runs/21947076544 when using the test matrix.

