### PR TITLE
Add tox option `skip_test_extra`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,15 @@ basepython = /usr/bin/python3.8
 """
 ```
 
+Almost all packages have a `test` extra, and we install it.
+A few don't, and this gives an error with `tox` 4.36.0+.
+So you can skip it:
+
+```toml
+[tox]
+skip_test_extra = true
+```
+
 Extend the list of `extras` that need to be installed for running the test suite and generate the coverage report by setting them on the `test_extras` key.
 
 ```toml

--- a/news/325.bugfix.md
+++ b/news/325.bugfix.md
@@ -1,0 +1,4 @@
+Add tox option `skip_test_extra`.
+Packages that don't have the standard `test` extra should set this option.
+Otherwise tests fail latest `tox`.
+@mauritsvanrees

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -404,6 +404,7 @@ class PackageConfiguration:
                 "config_lines",
                 "test_deps_additional",
                 "test_extras",
+                "skip_test_extra",
                 "test_environment_variables",
                 "extra_lines",
                 "use_pytest_plone",

--- a/src/plone/meta/default/tox-base.j2
+++ b/src/plone/meta/default/tox-base.j2
@@ -33,12 +33,15 @@ deps =
 #  constraints_file = "https://my-server.com/constraints.txt"
 ##
 extras =
+{% if not skip_test_extra %}
     test
+{% endif %}
 %(test_extras)s
 %(testenv_options)s
 ##
 # Add extra configuration options in .meta.toml:
 #  [tox]
+#  skip_test_extra = true
 #  test_extras = """
 #      tests
 #      widgets


### PR DESCRIPTION
Packages that don't have the standard `test` extra should set this option. Otherwise tests fail latest `tox`.
Fixes https://github.com/plone/meta/issues/325

Applied in the following PRs:

* https://github.com/plone/plone.intelligenttext/pull/44
* https://github.com/plone/plone.autoinclude/pull/47
