### PR TITLE
Bump isort and black versions

### DIFF
--- a/src/plone/meta/default/pre-commit-config.yaml.j2
+++ b/src/plone/meta/default/pre-commit-config.yaml.j2
@@ -9,11 +9,11 @@ repos:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/pycqa/isort
-    rev: 7.0.0
+    rev: 8.0.0
     hooks:
     -   id: isort
 -   repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 25.12.0
+    rev: 26.1.0
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty


### PR DESCRIPTION
These versions fix the problem we were having on the pre-commit bot PRs:

`black` was changing the amount of lines between imports and code, but `isort` wanted those lines back.
