### PR TITLE
Update to Python 3.14, Debian Trixie

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The dictionary keys needs to be Python versions and the value a Docker image for
 
 ```toml
 [gitlab]
-custom_images = {"3.13" = "python:3.13-bookworm", "3.12" = "python:3.12-bookworm"}
+custom_images = {"3.14" = "python:3.14-trixie", "3.13" = "python:3.13-trixie"}
 ```
 
 > [!TIP]

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,6 @@ This file describes the breaking changes between major versions.
 
 ## From `main` to `2.x`
 
-
 ### Test matrix
 
 You can now define the combinations of Plone versions and Python versions to be tested.
@@ -22,7 +21,6 @@ This will be used to generate the necessary `tox` environments and the GitHub Ac
 > 🍀 `plone.meta` tries to be a bit more environmentally friendly.
 > On GitHub, only the first and last Python versions will be added for testing.
 
-
 ### Constraints
 
 The `constraints_file` option in `.meta.toml`'s `[tox]` table was renamed to `constraints_files`, and the type of its value was changed from a string to a dictionary.
@@ -39,7 +37,6 @@ constraints_file = "https://example.org/my-custom-constraints.txt"
 constraints_files = {"6.2" = "https://example.org/constraints.6.2.txt", "6.1" = "https://example.org/constraints.6.1.txt"}
 ```
 
-
 ### GitHub Actions
 
 The `py_versions` option in `.meta.toml`'s `[github]` table is deprecated.
@@ -48,7 +45,6 @@ We use the new `test_matrix` option from `[tox]` table, as we now can run multip
 ### GitHub variables
 
 The GitHub variables `TEST_OS_VERSIONS` and `TEST_PYTHON_VERSIONS` are deprecated and no longer used.
-
 
 ### GitLab images
 
@@ -63,5 +59,5 @@ The dictionary keys must be Python versions, and the values a Docker image for t
 # OLD
 custom_images = "python:3.11-bullseye"
 # NEW
-custom_images = {"3.13" = "python:3.13-bookworm", "3.12" = "python:3.12-bookworm"}
+custom_images = {"3.14" = "python:3.14-trixie", "3.13" = "python:3.13-trixie"}
 ```

--- a/news/+py314-trixie.feature.md
+++ b/news/+py314-trixie.feature.md
@@ -1,0 +1,5 @@
+Switch to Debian Trixie, more updates to Python 3.14.
+
+Use Debian Trixie for all Platforms, remove the 3.9 image reference and add
+more updates Python 3.14 support.
+[thet]

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -41,11 +41,11 @@ TOX_TEST_MATRIX = {
 MXDEV_CONSTRAINTS = "constraints-mxdev.txt"
 
 DOCKER_IMAGES = {
-    "3.13": "python:3.13-bookworm",
-    "3.12": "python:3.12-bookworm",
-    "3.11": "python:3.11-bookworm",
-    "3.10": "python:3.10-bookworm",
-    "3.9": "python:3.9-bookworm",
+    "3.14": "python:3.14-trixie",
+    "3.13": "python:3.13-trixie",
+    "3.12": "python:3.12-trixie",
+    "3.11": "python:3.11-trixie",
+    "3.10": "python:3.10-trixie",
 }
 
 # Rather than pointing configured repositories to `plone.meta`'s `main` branch
@@ -156,7 +156,7 @@ def get_test_matrix(test_matrix):
     Example output:
 
         {
-            "6.2": ["3.13", "3.12", "3.11", "3.10"],
+            "6.2": ["3.14", "3.13", "3.12", "3.11", "3.10"],
             "6.1": ["3.11"],
         }
     """

--- a/src/plone/meta/default/gitlab-ci.yml.j2
+++ b/src/plone/meta/default/gitlab-ci.yml.j2
@@ -2,7 +2,7 @@ image: %(custom_image)s
 ##
 # Add extra configuration options in .meta.toml:
 #  [gitlab]
-#  custom_images = {"3.13" = "python:3.13-bookworm", "3.12" = "python:3.12-bookworm"}
+#  custom_images = {"3.14" = "python:3.14-trixie", "3.13" = "python:3.13-trixie"}
 ##
 
 stages:


### PR DESCRIPTION
Add support for Python 3.14 for Plone 6.2 and change to debian trixie image for all Python versions.