### PR TITLE
Dynamic python version for black and pyupgrade

### DIFF
--- a/news/285.feature
+++ b/news/285.feature
@@ -1,0 +1,1 @@
+Update `black` and `pyupgrade` to use the lowest python version supported from the test matrix @gforcada

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -322,6 +322,22 @@ class PackageConfiguration:
         options = self._get_options_for("gitignore", ("extra_lines",))
         return self.copy_with_meta("gitignore.j2", self.path / ".gitignore", **options)
 
+    def _minimal_python_version(self):
+        """Detect the minimal Python version to be used in tooling (black, pre-commit...).
+
+        Returns something like "3.10".
+        """
+        options = self._get_options_for("tox", ("test_matrix",))
+        test_matrix = get_test_matrix(options.get("test_matrix"))
+        min_version = None
+        for python_versions in test_matrix.values():
+            for py_version in python_versions:
+                if py_version.startswith("pypy"):
+                    continue
+                if min_version is None or py_version < min_version:
+                    min_version = py_version
+        return min_version
+
     def pre_commit_config(self):
         options = self._get_options_for(
             "pre_commit",
@@ -333,6 +349,9 @@ class PackageConfiguration:
                 "i18ndude_extra_lines",
             ),
         )
+
+        python_version = self._minimal_python_version()
+        options["minimal_python_version"] = self._no_dot_python_version(python_version)
 
         return self.copy_with_meta(
             "pre-commit-config.yaml.j2",
@@ -359,6 +378,9 @@ class PackageConfiguration:
                 "extra_lines",
             ),
         )
+
+        python_version = self._minimal_python_version()
+        options["minimal_python_version"] = self._no_dot_python_version(python_version)
 
         options["changes_extension"] = "rst"
         if (self.path / "CHANGES.md").exists():

--- a/src/plone/meta/default/pre-commit-config.yaml.j2
+++ b/src/plone/meta/default/pre-commit-config.yaml.j2
@@ -7,7 +7,7 @@ repos:
     rev: v3.21.2
     hooks:
     -   id: pyupgrade
-        args: [--py38-plus]
+        args: [--%(minimal_python_version)s-plus]
 -   repo: https://github.com/pycqa/isort
     rev: 8.0.0
     hooks:

--- a/src/plone/meta/default/pyproject.toml.j2
+++ b/src/plone/meta/default/pyproject.toml.j2
@@ -71,7 +71,7 @@ profile = "plone"
 ##
 
 [tool.black]
-target-version = ["py38"]
+target-version = ["%(minimal_python_version)s"]
 %(black_extra_lines)s
 ##
 # Add extra configuration options in .meta.toml:


### PR DESCRIPTION
Closes #285 

@thet would an automatic suggestion be good enough? Or you really want to specify a random python version? 🤔 

What we do in this PR is to get the lowest python version supported on the test matrix and use that for both `black` and `pyupgrade`.

Would that be enough?
