### PR TITLE
No trailing colons on changes subheadings

### DIFF
--- a/news/+no-colon.bugfix
+++ b/news/+no-colon.bugfix
@@ -1,0 +1,1 @@
+Do not add trailing colons on changes subheadings @gforcada

--- a/src/plone/meta/default/pyproject.toml.j2
+++ b/src/plone/meta/default/pyproject.toml.j2
@@ -22,32 +22,32 @@ issue_format = "%(towncrier_issue_format)s"
 
 [[tool.towncrier.type]]
 directory = "breaking"
-name = "Breaking changes:"
+name = "Breaking changes{% if changes_extension == 'rst'%}:{% endif %}"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "feature"
-name = "New features:"
+name = "New features{% if changes_extension == 'rst'%}:{% endif %}"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "bugfix"
-name = "Bug fixes:"
+name = "Bug fixes{% if changes_extension == 'rst'%}:{% endif %}"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "internal"
-name = "Internal:"
+name = "Internal{% if changes_extension == 'rst'%}:{% endif %}"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "documentation"
-name = "Documentation:"
+name = "Documentation{% if changes_extension == 'rst'%}:{% endif %}"
 showcontent = true
 
 [[tool.towncrier.type]]
 directory = "tests"
-name = "Tests:"
+name = "Tests{% if changes_extension == 'rst'%}:{% endif %}"
 showcontent = true
 %(towncrier_extra_lines)s
 {% endif %}


### PR DESCRIPTION
On markdown rendered `CHANGES.md` each section is a subheading, thus
a colon ending it is rather off:

```md
## Version X.Y.Z

### New features:

- la li lu

### Bugfixes:

- li lo la
```

OTOH on rst rendered `CHANGES.rst` each section starts a list, which
makes sense to finish it with a colon.

```rst
Version X.Y.Z
=============

New features:

- la li lu

Bugfixes:

- lo la li
```