### PR TITLE
Detect upper bound for setuptools in build-system.

### DIFF
--- a/news/+8bdbf183.feature.md
+++ b/news/+8bdbf183.feature.md
@@ -1,0 +1,3 @@
+Detect upper bound for setuptools in build-system.
+For `pkg_resources` namespaces, use `setuptools<82`, otherwise `setuptools<83`.
+@mauritsvanrees

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # This is the pyproject.toml of plone.meta itself, *not* of generated projects.
 
 [build-system]
-requires = ["setuptools>=68.2,<80", "wheel"]
+requires = ["setuptools>=68.2,<83", "wheel"]
 # We must set a build-backend, because the default build-backend needs a setup.py.
 build-backend = "setuptools.build_meta"
 

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -338,6 +338,23 @@ class PackageConfiguration:
                     min_version = py_version
         return min_version
 
+    def _setuptools_upper_bound(self):
+        """Determine upper bound for setuptools in build-system.
+
+        This will be set in pyproject.toml:
+
+          requires = ["setuptools>=68.2,<upper_bound", "wheel"]
+
+        setuptools 82 has removed the pkg_resources module.
+        So if the package uses pkg_resources.declare_namespace, we return
+        "82" as upper bound.  Otherwise "83".  We could leave the upper bound
+        away in that case, but we have experience with things breaking with
+        a new setuptools release, so let's be careful.
+        """
+        if self._detect_pkg_resources_namespace():
+            return "82"
+        return "83"
+
     def pre_commit_config(self):
         options = self._get_options_for(
             "pre_commit",
@@ -381,6 +398,7 @@ class PackageConfiguration:
 
         python_version = self._minimal_python_version()
         options["minimal_python_version"] = self._no_dot_python_version(python_version)
+        options["setuptools_upper_bound"] = self._setuptools_upper_bound()
 
         options["changes_extension"] = "rst"
         if (self.path / "CHANGES.md").exists():
@@ -553,6 +571,13 @@ class PackageConfiguration:
                 text = file_obj.read_text()
                 if "plone.app.robotframework" in text:
                     return True
+        return False
+
+    def _detect_pkg_resources_namespace(self):
+        """Dynamically find out if package uses pkg_resources namespaces."""
+        for file_obj in self.path.glob("src/*/__init__.py"):
+            if "declare_namespace(__name__)" in file_obj.read_text():
+                return True
         return False
 
     def news_entry(self):

--- a/src/plone/meta/default/pyproject.toml.j2
+++ b/src/plone/meta/default/pyproject.toml.j2
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.2,<80", "wheel"]
+requires = ["setuptools>=68.2,<%(setuptools_upper_bound)s", "wheel"]
 
 {% if news_folder_exists %}
 [tool.towncrier]


### PR DESCRIPTION
For `pkg_resources` namespaces, use `setuptools<82`, otherwise `setuptools<83`.

We need something like this, otherwise we will either stick to an old version (`setuptools<80`) for a long time, or we can no longer use plone.meta to update maintenance branches for Plone 6.1, where most packages still use `pkg_resources` namespaces.