### PR TITLE
Pin sphinx<9.1 for docs build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -105,7 +105,7 @@ DOCS_LINKCHECK_FOLDER?=docs/linkcheck
 
 # Documentation Python requirements to be installed (via pip).
 # No default value.
-DOCS_REQUIREMENTS?=myst_parser plone-sphinx-theme sphinx-design sphinx-copybutton
+DOCS_REQUIREMENTS?=myst_parser plone-sphinx-theme sphinx-design sphinx-copybutton "sphinx<9.1"
 
 ##############################################################################
 # END SETTINGS - DO NOT EDIT BELOW THIS LINE

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -105,7 +105,7 @@ DOCS_LINKCHECK_FOLDER?=docs/linkcheck
 
 # Documentation Python requirements to be installed (via pip).
 # No default value.
-DOCS_REQUIREMENTS?=myst_parser plone-sphinx-theme sphinx-design sphinx-copybutton "sphinx<9.1"
+DOCS_REQUIREMENTS?=myst_parser plone-sphinx-theme sphinx-design sphinx-copybutton "sphinx<9"
 
 ##############################################################################
 # END SETTINGS - DO NOT EDIT BELOW THIS LINE


### PR DESCRIPTION
Fixes #352

Sphinx 9.1 requires `theme.toml` for theme discovery. `plone-sphinx-theme` doesn't have it yet (plone/plone-sphinx-theme#82). Pin `sphinx<9.1` until the theme is updated.