### PR TITLE
fix(gha): run meta jobs on maintenance branches

### DIFF
--- a/news/+37012a6b.bugfix.md
+++ b/news/+37012a6b.bugfix.md
@@ -1,0 +1,1 @@
+Add workflow_dispatch trigger for generated test-matrix workflows.  @mauritsvanrees

--- a/news/337.bugfix
+++ b/news/337.bugfix
@@ -1,0 +1,1 @@
+Allow maintenance branches to run GHA workflows from `meta.yml` @gforcada

--- a/src/plone/meta/default/meta.yml.j2
+++ b/src/plone/meta/default/meta.yml.j2
@@ -2,6 +2,7 @@ name: Meta
 
 on:
   push:
+  workflow_dispatch:
 
 {% if env %}
 env:

--- a/src/plone/meta/default/meta.yml.j2
+++ b/src/plone/meta/default/meta.yml.j2
@@ -1,14 +1,7 @@
 name: Meta
+
 on:
   push:
-    branches:
-      - master
-      - main
-  pull_request:
-    branches:
-      - master
-      - main
-  workflow_dispatch:
 
 {% if env %}
 env:

--- a/src/plone/meta/default/test-matrix.yml.j2
+++ b/src/plone/meta/default/test-matrix.yml.j2
@@ -2,6 +2,7 @@ name: Tests
 
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Closes #337 

As it was restricted to `main` and `master` any maintenance branch, say `3.x` would never run GHA from this file, i.e. qa, dependencies, coverage, etc.
