### PR TITLE
Update z3c.dependencychecker

### DIFF
--- a/news/+dependencies.feature
+++ b/news/+dependencies.feature
@@ -1,0 +1,1 @@
+Update `z3c.dependencychecker` @gforcada

--- a/src/plone/meta/default/tox-qa.j2
+++ b/src/plone/meta/default/tox-qa.j2
@@ -22,10 +22,9 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
-    setuptools<82.0.0
-    z3c.dependencychecker==2.14.3
+    z3c.dependencychecker==3.0
 commands =
-    python -m build --sdist
+    python -m build --wheel
     dependencychecker
 
 [testenv:dependencies-graph]

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ description = check if the package defines all its dependencies
 skip_install = true
 deps =
     build
-    z3c.dependencychecker==2.14.3
+    z3c.dependencychecker==3.0
 commands =
     python -m build --sdist
     dependencychecker


### PR DESCRIPTION
Finally the 3.0 version is out 🎉 and free from `pkg_resources`, which basically meant quite a re-write from the extraction logic 🙃 

A first test against all repositories on my `buildout.coredev/src/plone.*` showed almost no differences with the existing version 🍀 