### PR TITLE
Add clearer warning on main branch to not use it.

### DIFF
--- a/DO_NOT_USE_THIS_BRANCH.md
+++ b/DO_NOT_USE_THIS_BRANCH.md
@@ -1,0 +1,5 @@
+# WARNING
+
+Since February 11th 2025 `plone.meta` is not using `main` branch for development anymore.
+Have a look at the current default branch in the GitHub UI (at time of writing: 2.x).
+If you really want to use the current branch, pass `--yes` as option.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 > [!WARNING]
-> Since February 11th 2025 `plone.meta` is not using `main` branch for development anymore,
-> have a look at the current default branch on GitHub UI.
+> Since February 11th 2025 `plone.meta` is not using `main` branch for development anymore.
+> Have a look at the current default branch in the GitHub UI (at time of writing: 2.x).
+> If you really want to use the current branch, pass `--yes` as option.
 
 # plone/meta
 
@@ -40,7 +41,7 @@ When you run this command, it automatically goes through the following steps.
 1.  It writes the configuration files.
 1.  It creates a change log entry.
 1.  By default, it commits changes.
-1.  It optionally adds packages, pushes commits, or runs tox from the configuration files. 
+1.  It optionally adds packages, pushes commits, or runs tox from the configuration files.
 
 > [!TIP]
 > If you prefer to name the new git branch instead of letting the command name it using its default naming scheme, then either create a new branch `my-new-branch`, switch to it, and use the `--branch current` option, or do all that in one step with the `--branch my-new-branch` option.

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -14,6 +14,7 @@ import jinja2
 import pathlib
 import re
 import shutil
+import sys
 import tomlkit
 import validate_pyproject
 import yaml
@@ -65,9 +66,32 @@ GITLAB_DEFAULT_JOBS = [
 
 def handle_command_line_arguments():
     """Parse command line options"""
-    parser = argparse.ArgumentParser(description="Use configuration for a package.")
+    # Note: the line endings in the following branch text are ignored in the
+    # command description, but they are shown when we explicitly print this
+    # at the end of this function.
+    branch_text = (
+        "You should NOT use this main branch.\n"
+        "Have a look at the current default branch in the GitHub UI "
+        "(at time of writing: 2.x).\n"
+        "If you really want to use the current branch, pass --yes as option."
+    )
+
+    parser = argparse.ArgumentParser(
+        description=f"Use configuration for a package. WARNING: {branch_text}"
+    )
+    # parser = argparse.ArgumentParser(
+    #     description="Use configuration for a package. "
+    #     "WARNING: you should NOT use the main branch. "
+    #     "Use a version branch like 2.x instead.")
     parser.add_argument(
         "path", type=pathlib.Path, help="path to the repository to be configured"
+    )
+    parser.add_argument(
+        "--yes",
+        dest="yes",
+        action="store_true",
+        default=False,
+        help="Yes, use this branch.",
     )
     parser.add_argument(
         "--commit-msg",
@@ -124,6 +148,9 @@ def handle_command_line_arguments():
     )
 
     args = parser.parse_args()
+    if not args.yes:
+        print(f"ERROR: {branch_text}")
+        sys.exit(1)
     return args
 
 


### PR DESCRIPTION
Add file `DO_NOT_USE_THIS_BRANCH.md`.  And show an error when you call the command:

```
$ ./venv/bin/config-package foo
ERROR: You should NOT use this main branch.
Have a look at the current default branch in the GitHub UI (at time of writing: 2.x).
If you really want to use the current branch, pass --yes as option.
```

Note: please double check that this PR targets the **main** branch. :-D