### PR TITLE
pre-commit: zpretty 4.0.0, check-python-versions 0.24.2

### DIFF
--- a/src/plone/meta/default/pre-commit-config.yaml.j2
+++ b/src/plone/meta/default/pre-commit-config.yaml.j2
@@ -17,7 +17,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
-    rev: 3.1.1
+    rev: 4.0.0
     hooks:
     -   id: zpretty
 %(zpretty_extra_lines)s
@@ -63,7 +63,7 @@ repos:
     hooks:
     -   id: pyroma
 -   repo: https://github.com/mgedmin/check-python-versions
-    rev: "0.24.0"
+    rev: "0.24.2"
     hooks:
     -   id: check-python-versions
         args: ['--only', '%(check_python_versions_files)s']


### PR DESCRIPTION
When I apply this and then run `pre-commit autoupdate` we get two extra changes that I don't think we want:

```
[https://github.com/pycqa/isort] updating 8.0.1 -> 9.0.0a3
[https://github.com/collective/zpretty] updating 4.0.0 -> 4.0.0.dev0
```

I searched in the `pre-commit` repo and there are lots of [issues about autoupdate](https://github.com/pre-commit/pre-commit/issues?q=is%3Aissue%20state%3Aclosed%20autoupdate) that are closed.  Most seem to reiterate ideas about optionally disallowing prereleases, or similar changes, which the maintainer/creator closes because he simply wants to use the latest tag.  So there does not seem to be a way around this.

I am a bit concerned that we may get these changes proposed the next time pre-commit.ci does its monthly update.   I guess we will see.

BTW, we may want to call `pre-commit autoupdate --freeze`.  This changes the config like this:

```
 repos:
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
+    rev: 75992aaa40730136014f34227e0135f63fc951b4  # frozen: v3.21.2
```

But I am not sure if pre-commit.ci keeps these frozen revs.

Anyway, I will make a few PRs to test the small current changes. :-)