### PR TITLE
Restore Python 3.9 as one of the default Pythons for Plone 6.0.

### DIFF
--- a/news/+d323c2b0.bugfix.md
+++ b/news/+d323c2b0.bugfix.md
@@ -1,0 +1,1 @@
+Restore Python 3.9 as one of the default Pythons for Plone 6.0.  @mauritsvanrees

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -36,7 +36,7 @@ DEFAULT = object()
 TOX_TEST_MATRIX = {
     "6.2": ["3.14", "3.13", "3.12", "3.11", "3.10"],
     "6.1": ["3.13", "3.12", "3.11", "3.10"],
-    "6.0": ["3.13", "3.12", "3.11", "3.10"],
+    "6.0": ["3.13", "3.12", "3.11", "3.10", "3.9"],
 }
 
 MXDEV_CONSTRAINTS = "constraints-mxdev.txt"
@@ -47,6 +47,7 @@ DOCKER_IMAGES = {
     "3.12": "python:3.12-trixie",
     "3.11": "python:3.11-trixie",
     "3.10": "python:3.10-trixie",
+    "3.9": "python:3.9-trixie",
 }
 
 # Rather than pointing configured repositories to `plone.meta`'s `main` branch

--- a/tests/test_package_config_ci.py
+++ b/tests/test_package_config_ci.py
@@ -129,7 +129,8 @@ class TestMinimalPythonVersion:
     @pytest.mark.parametrize(
         ["matrix", "output"],
         [
-            [None, "3.10"],
+            [None, "3.9"],
+            [{"6.0": ["*"]}, "3.9"],
             [{"6.1": ["*"]}, "3.10"],
             [{"6.2": ["*"]}, "3.10"],
             [{"6.2": ["3.13"]}, "3.13"],


### PR DESCRIPTION
See https://github.com/plone/plone.folder/pull/54#issuecomment-4352460937 and further comments.
