### PR TITLE
Add Plone 6.3 to the test matrix.

### DIFF
--- a/news/+0b9c605e.feature.md
+++ b/news/+0b9c605e.feature.md
@@ -1,0 +1,3 @@
+Add Plone 6.3 to the test matrix.
+Test this on Python 3.10-3.14.
+@mauritsvanrees

--- a/src/plone/meta/config_package.py
+++ b/src/plone/meta/config_package.py
@@ -34,6 +34,7 @@ DEFAULT = object()
 
 # List all python versions we want to test a given Plone version against
 TOX_TEST_MATRIX = {
+    "6.3": ["3.14", "3.13", "3.12", "3.11", "3.10"],
     "6.2": ["3.14", "3.13", "3.12", "3.11", "3.10"],
     "6.1": ["3.13", "3.12", "3.11", "3.10"],
     "6.0": ["3.13", "3.12", "3.11", "3.10", "3.9"],


### PR DESCRIPTION
Test this on Python 3.10-3.14 for now.
That will likely be changed to 3.11 minimum, but that is pending this PLIP: https://github.com/plone/Products.CMFPlone/issues/4326

Sample PR on `plone.releaser`:
https://github.com/plone/plone.releaser/pull/102