### PR TITLE
Allow custom path and options to be passed to zpretty in backend-lint

### DIFF
--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -32,6 +32,14 @@ on:
         required: false
         default: 'latest'
         type: string
+      zpretty-check-path:
+        required: false
+        default: 'src'
+        type: string
+      zpretty-options:
+        required: false
+        default: ''
+        type: string
 
 jobs:
 
@@ -73,7 +81,7 @@ jobs:
         id: zpretty
         shell: bash
         run: |
-          uvx zpretty@${{ inputs.version-zpretty }} --check src
+          uvx zpretty@${{ inputs.version-zpretty }} --check ${{ inputs.zpretty-check-path }} ${{ inputs.zpretty-options }}
 
       - name: Check Package Metadata
         if: ${{ success() || failure() }}

--- a/docs/sources/reference/shared-workflows.md
+++ b/docs/sources/reference/shared-workflows.md
@@ -80,7 +80,22 @@ steps:
 
 ### backend-lint
 
-Runs backend linting checks.
+Runs backend linting checks: `ruff` (format and lint), `zpretty` (XML / ZCML), `pyroma` (package metadata), `check-python-versions`, and optionally `mypy` (typing).
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `python-version` | Python version to install | Yes | |
+| `plone-version` | Plone version to install | Yes | |
+| `working-directory` | Directory to run the checks in | No | `"."` |
+| `check-typing` | Run `mypy` type checking on `src` | No | `false` |
+| `version-ruff` | Version of `ruff` to use | No | `"latest"` |
+| `version-zpretty` | Version of `zpretty` to use | No | `"latest"` |
+| `version-pyroma` | Version of `pyroma` to use | No | `"latest"` |
+| `version-check-python` | Version of `check-python-versions` to use | No | `"latest"` |
+| `zpretty-check-path` | Path checked by `zpretty` | No | `"src"` |
+| `zpretty-options` | Additional command-line options passed to `zpretty` | No | `""` |
 
 **Example usage:**
 
@@ -88,6 +103,11 @@ Runs backend linting checks.
 jobs:
   backend-lint:
     uses: plone/meta/.github/workflows/backend-lint.yml@2.x
+    with:
+      python-version: "3.12"
+      plone-version: "6.1"
+      zpretty-check-path: "src"
+      zpretty-options: '--extend-exclude "/rss/(rss\.xml|search-rss)\.pt$"'
 ```
 
 ### backend-pytest

--- a/news/389.feature
+++ b/news/389.feature
@@ -1,0 +1,1 @@
+Added `zpretty-check-path` and `zpretty-options` inputs to the `backend-lint` reusable workflow, allowing a custom check path and additional command-line options to be passed to `zpretty`. @ericof


### PR DESCRIPTION
## Summary

Adds two new optional inputs to the `backend-lint` reusable workflow so callers can control how `zpretty` is invoked:

- **`zpretty-check-path`** (default `'src'`) — the path checked by `zpretty`. Previously hardcoded to `src`.
- **`zpretty-options`** (default `''`) — additional command-line options passed through to `zpretty` (e.g. `--extend-exclude`).

## Changes

- `.github/workflows/backend-lint.yml`: new inputs wired into the `zpretty --check` invocation.
- `docs/sources/reference/shared-workflows.md`: documented all `backend-lint` inputs in a table and added a usage example.
- `news/389.feature`: changelog fragment.

## Notes

The `zpretty-options` value is expanded by **bash** in the workflow `run:` step (not Make), so a regex end anchor must be a single `$` — the documented example reflects this:

```yaml
zpretty-options: '--extend-exclude "/rss/(rss\.xml|search-rss)\.pt$"'
```

Refs #389