### PR TITLE
Secure GHA with zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -54,6 +54,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup codebase
         uses: plone/meta/.github/actions/setup_backend_uv@2.x

--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -69,35 +69,47 @@ jobs:
         id: ruff-format
         shell: bash
         run: |
-          uvx ruff@${{ inputs.version-ruff }} format --diff
+          uvx ruff@${INPUTS_VERSION_RUFF} format --diff
+        env:
+          INPUTS_VERSION_RUFF: ${{ inputs.version-ruff }}
 
       - name: Check lint
         if: ${{ success() || failure() }}
         id: ruff-lint
         shell: bash
         run: |
-          uvx ruff@${{ inputs.version-ruff }} check --diff
+          uvx ruff@${INPUTS_VERSION_RUFF} check --diff
+        env:
+          INPUTS_VERSION_RUFF: ${{ inputs.version-ruff }}
 
       - name: Check XML / ZCML
         if: ${{ success() || failure() }}
         id: zpretty
         shell: bash
         run: |
-          uvx zpretty@${{ inputs.version-zpretty }} --check ${{ inputs.zpretty-check-path }} ${{ inputs.zpretty-options }}
+          uvx zpretty@${INPUTS_VERSION_ZPRETTY} --check ${INPUTS_ZPRETTY_CHECK_PATH} ${INPUTS_ZPRETTY_OPTIONS}
+        env:
+          INPUTS_VERSION_ZPRETTY: ${{ inputs.version-zpretty }}
+          INPUTS_ZPRETTY_CHECK_PATH: ${{ inputs.zpretty-check-path }}
+          INPUTS_ZPRETTY_OPTIONS: ${{ inputs.zpretty-options }}
 
       - name: Check Package Metadata
         if: ${{ success() || failure() }}
         id: pyroma
         shell: bash
         run: |
-          uvx pyroma@${{ inputs.version-pyroma }} -d .
+          uvx pyroma@${INPUTS_VERSION_PYROMA} -d .
+        env:
+          INPUTS_VERSION_PYROMA: ${{ inputs.version-pyroma }}
 
       - name: Check Python Versions
         if: ${{ success() || failure() }}
         id: py-versions
         shell: bash
         run: |
-          uvx check-python-versions@${{ inputs.version-check-python }} .
+          uvx check-python-versions@${INPUTS_VERSION_CHECK_PYTHON} .
+        env:
+          INPUTS_VERSION_CHECK_PYTHON: ${{ inputs.version-check-python }}
 
       - name: Check typing
         if: ${{ (success() || failure()) && inputs.check-typing }}

--- a/.github/workflows/backend-pytest-coverage.yml
+++ b/.github/workflows/backend-pytest-coverage.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup codebase
         uses: plone/meta/.github/actions/setup_backend_uv@2.x

--- a/.github/workflows/backend-pytest.yml
+++ b/.github/workflows/backend-pytest.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup codebase
         uses: plone/meta/.github/actions/setup_backend_uv@2.x

--- a/.github/workflows/circular.yml
+++ b/.github/workflows/circular.yml
@@ -16,6 +16,8 @@ jobs:
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install uv + caching
         uses: astral-sh/setup-uv@v7.5.0
         with:

--- a/.github/workflows/container-image-build-push.yml
+++ b/.github/workflows/container-image-build-push.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/container-image-build.yml
+++ b/.github/workflows/container-image-build.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/container-image-push.yml
+++ b/.github/workflows/container-image-push.yml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,8 @@ jobs:
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install uv + caching
         uses: astral-sh/setup-uv@v7.5.0
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -33,7 +33,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: install OS packages
         if: inputs.os-packages != ''
-        run: sudo apt-get install -y ${{ inputs.os-packages }}
+        run: sudo apt-get install -y ${INPUTS_OS_PACKAGES}
+        env:
+          INPUTS_OS_PACKAGES: ${{ inputs.os-packages }}
       - name: Initialize tox
         run: |
           if [ `uvx tox list --no-desc -f init|wc -l` = 1 ]; then uvx --with tox-uv tox -e init;else true; fi

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -16,6 +16,8 @@ jobs:
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install uv + caching
         uses: astral-sh/setup-uv@v7.5.0
         with:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -27,6 +27,8 @@ jobs:
         working-directory: ${{ inputs.working-directory }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: plone/meta/.github/actions/setup_uv@2.x

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v7
         with:

--- a/.github/workflows/frontend-acceptance.yml
+++ b/.github/workflows/frontend-acceptance.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Main checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Setup uv
         uses: plone/meta/.github/actions/setup_uv@2.x
         with:

--- a/.github/workflows/frontend-code.yml
+++ b/.github/workflows/frontend-code.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Main checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: plone/meta/.github/actions/setup_uv@2.x

--- a/.github/workflows/frontend-i18n.yml
+++ b/.github/workflows/frontend-i18n.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Main checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: plone/meta/.github/actions/setup_uv@2.x

--- a/.github/workflows/frontend-storybook.yml
+++ b/.github/workflows/frontend-storybook.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Main checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: plone/meta/.github/actions/setup_uv@2.x

--- a/.github/workflows/frontend-unit.yml
+++ b/.github/workflows/frontend-unit.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Main checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup uv
         uses: plone/meta/.github/actions/setup_uv@2.x

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -1,5 +1,6 @@
 name: CI
 on: [push]
+permissions: {}
 
 jobs:
   qa:

--- a/.github/workflows/local.yml
+++ b/.github/workflows/local.yml
@@ -10,6 +10,8 @@ jobs:
         python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install uv + caching
         uses: astral-sh/setup-uv@v7.5.0
         with:
@@ -29,6 +31,8 @@ jobs:
         python-version: ["3.11", "3.14"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install uv + caching
         uses: astral-sh/setup-uv@v7.5.0
         with:
@@ -48,6 +52,8 @@ jobs:
         python-version: ["3.14"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install uv + caching
         uses: astral-sh/setup-uv@v7.5.0
         with:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -16,6 +16,8 @@ jobs:
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install uv + caching
         uses: astral-sh/setup-uv@v7.5.0
         with:

--- a/.github/workflows/release_ready.yml
+++ b/.github/workflows/release_ready.yml
@@ -16,6 +16,8 @@ jobs:
         os: ["ubuntu-latest"]
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install uv + caching
         uses: astral-sh/setup-uv@v7.5.0
         with:

--- a/news/384.feature
+++ b/news/384.feature
@@ -1,0 +1,1 @@
+Implement security measures from `zizmor` @gforcada

--- a/src/plone/meta/default/dependabot.yml
+++ b/src/plone/meta/default/dependabot.yml
@@ -6,3 +6,5 @@ updates:
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/src/plone/meta/default/meta.yml.j2
+++ b/src/plone/meta/default/meta.yml.j2
@@ -1,4 +1,5 @@
 name: Meta
+permissions: {}
 
 on:
   push:


### PR DESCRIPTION
Part of #384 

> [!note]
> ⚠️ I'm not adding `zizmor` either as a GHA nor within pre-commit or such. The reason being that `zizmor` complains, rightfully so, about GHA not using hash-pinning, but can not update it.
>
> [pinact](https://github.com/suzuki-shunsuke/pinact) or tools like that can, but need to be checked first how to integrate them.
>
> While we discuss and prototype how to best integrate it, the first quick fixes from `zizmor` are already worth merging IMHO.


@ericof if you run `uvx zizmor .` in this repository there are a few warning about some actions that you added, could you have a look whenever you have time, they are about token permissions and their scope, which I don't have enough knowledge about the actions themselves to make an estimated guess on what would be the proper fix.