### PR TITLE
Document shared workflow inputs and the quoting rules for options inputs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      # Covers `.github/workflows` and a root-level `action.yml` only.
+      - "/"
+      # Our composite actions live one directory deeper, so `/` does not
+      # reach them and their dependencies are never updated.
+      - "/.github/actions/*"
     schedule:
       # Check for updates to GitHub Actions every week
       interval: "weekly"

--- a/docs/sources/reference/shared-workflows.md
+++ b/docs/sources/reference/shared-workflows.md
@@ -16,6 +16,40 @@ These are **not** used by the `config-package` tool; they are designed to be cal
 
 All workflows and actions are located in the plone.meta repository and referenced via `uses:` in your project's workflow files.
 
+## Permissions
+
+None of the reusable workflows declare a `permissions:` block of their own.
+A reusable workflow cannot grant more access than its caller already has, so the **caller** is responsible for declaring the permissions each workflow needs, either at the workflow level or on the calling job.
+
+The workflows that need more than the default read access say so in their own section below.
+
+(shared-workflows-quoting)=
+
+## Passing values to string inputs
+
+Some inputs are forwarded to a shell command as an environment variable and expanded **unquoted**, so that a single input can supply several command-line arguments.
+This has consequences worth knowing before you write such a value:
+
+- The value is split on whitespace, and each resulting word becomes a separate argument.
+- Quote characters are **not** removed.
+  A value wrapped in `"` or `'` reaches the tool with those characters still attached, which usually changes the meaning of the argument.
+- Glob metacharacters (`*`, `?`, `[`) are expanded against the working directory.
+
+Write these values **without quotes**:
+
+```yaml
+# Correct: the shell splits this into two arguments.
+zpretty-options: --extend-exclude /rss/(rss\.xml|search-rss)\.pt$
+
+# Wrong: zpretty receives the argument with literal " characters around it,
+# so the pattern matches nothing.
+zpretty-options: '--extend-exclude "/rss/(rss\.xml|search-rss)\.pt$"'
+```
+
+There is currently no way to pass an argument that itself contains whitespace.
+
+The inputs that behave this way are marked *word-split* in the tables below: {ref}`backend-lint <shared-workflows-backend-lint>`'s `zpretty-options` and {ref}`coverage <shared-workflows-coverage>`'s `os-packages`.
+
 ## Composite Actions
 
 ### setup_backend_uv
@@ -26,7 +60,9 @@ Sets up a Python backend environment using [uv](https://docs.astral.sh/uv/) as t
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `python-version` | Python version to install | No | `"3.12"` |
+| `python-version` | Python version to install | Yes | `"3.12"` |
+| `plone-version` | Plone version to install | Yes | `"6.2.0"` |
+| `working-directory` | Directory to run the installation in | No | `"."` |
 
 **Example usage:**
 
@@ -36,6 +72,7 @@ steps:
   - uses: plone/meta/.github/actions/setup_backend_uv@2.x
     with:
       python-version: "3.13"
+      plone-version: "6.2.0"
 ```
 
 ### setup_frontend
@@ -46,7 +83,10 @@ Sets up a Node.js frontend environment with dependency installation.
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `node-version` | Node.js version to install | No | `"22.x"` |
+| `node-version` | Node.js version to install | Yes | `"22.x"` |
+| `working-directory` | Directory to run the installation in | No | `"."` |
+| `cache` | Package-manager cache to enable | No | `"pnpm"` |
+| `cache-dependency-path` | Lockfile glob used as the cache key | No | `"**/pnpm-lock.yaml"` |
 
 **Example usage:**
 
@@ -60,13 +100,14 @@ steps:
 
 ### setup_uv
 
-Sets up the [uv](https://docs.astral.sh/uv/) package installer.
+Sets up the [uv](https://docs.astral.sh/uv/) package installer, without installing a project.
 
 **Inputs:**
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|---------|
-| `uv-version` | Version of uv to install | No | `"latest"` |
+| `python-version` | Python version to install | Yes | `"3.12"` |
+| `working-directory` | Directory to run `uv` in | No | `"."` |
 
 **Example usage:**
 
@@ -78,9 +119,13 @@ steps:
 
 ## Backend Workflows
 
+(shared-workflows-backend-lint)=
+
 ### backend-lint
 
 Runs backend linting checks: `ruff` (format and lint), `zpretty` (XML / ZCML), `pyroma` (package metadata), `check-python-versions`, and optionally `mypy` (typing).
+
+Every check runs even if an earlier one fails, and the results are collected into a job summary table.
 
 **Inputs:**
 
@@ -95,7 +140,7 @@ Runs backend linting checks: `ruff` (format and lint), `zpretty` (XML / ZCML), `
 | `version-pyroma` | Version of `pyroma` to use | No | `"latest"` |
 | `version-check-python` | Version of `check-python-versions` to use | No | `"latest"` |
 | `zpretty-check-path` | Path checked by `zpretty` | No | `"src"` |
-| `zpretty-options` | Additional command-line options passed to `zpretty` | No | `""` |
+| `zpretty-options` | Additional command-line options passed to `zpretty` (*word-split*, see {ref}`shared-workflows-quoting`) | No | `""` |
 
 **Example usage:**
 
@@ -107,12 +152,20 @@ jobs:
       python-version: "3.12"
       plone-version: "6.1"
       zpretty-check-path: "src"
-      zpretty-options: '--extend-exclude "/rss/(rss\.xml|search-rss)\.pt$"'
+      zpretty-options: --extend-exclude /rss/(rss\.xml|search-rss)\.pt$
 ```
 
 ### backend-pytest
 
-Runs backend tests with pytest.
+Runs the backend test suite by calling the project's `make test` target.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `python-version` | Python version to install | Yes | |
+| `plone-version` | Plone version to install | Yes | |
+| `working-directory` | Directory to run the tests in | No | `"."` |
 
 **Example usage:**
 
@@ -120,11 +173,22 @@ Runs backend tests with pytest.
 jobs:
   backend-pytest:
     uses: plone/meta/.github/workflows/backend-pytest.yml@2.x
+    with:
+      python-version: "3.12"
+      plone-version: "6.1"
 ```
 
 ### backend-pytest-coverage
 
-Runs backend tests with coverage reporting.
+Runs the backend test suite with coverage by calling the project's `make test-coverage` target, and writes the coverage report to the job summary.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `python-version` | Python version to install | Yes | |
+| `plone-version` | Plone version to install | Yes | |
+| `working-directory` | Directory to run the tests in | No | `"."` |
 
 **Example usage:**
 
@@ -132,13 +196,25 @@ Runs backend tests with coverage reporting.
 jobs:
   backend-pytest-coverage:
     uses: plone/meta/.github/workflows/backend-pytest-coverage.yml@2.x
+    with:
+      python-version: "3.12"
+      plone-version: "6.1"
 ```
 
 ## Documentation Workflows
 
 ### docs-build
 
-Builds project documentation.
+Builds project documentation with the project's `make install`, `make build`, `make linkcheckbroken` and `make vale` targets.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `python-version` | Python version to install | Yes | `"3.12"` |
+| `working-directory` | Directory holding the documentation | No | `"."` |
+| `check-links` | Run the broken-link check | No | `true` |
+| `check-vale` | Run the Vale prose checks | No | `true` |
 
 **Example usage:**
 
@@ -146,13 +222,24 @@ Builds project documentation.
 jobs:
   docs-build:
     uses: plone/meta/.github/workflows/docs-build.yml@2.x
+    with:
+      python-version: "3.12"
+      working-directory: "docs"
 ```
 
 ## Frontend Workflows
 
 ### frontend-acceptance
 
-Runs frontend acceptance (end-to-end) tests.
+Runs frontend acceptance (end-to-end) tests with Cypress, against servers started by the workflow.
+Screenshots and videos are uploaded as artifacts when the run fails.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `node-version` | Node.js version to install | Yes | |
+| `working-directory` | Directory to run the tests in | No | `"."` |
 
 **Example usage:**
 
@@ -160,11 +247,20 @@ Runs frontend acceptance (end-to-end) tests.
 jobs:
   frontend-acceptance:
     uses: plone/meta/.github/workflows/frontend-acceptance.yml@2.x
+    with:
+      node-version: "22.x"
 ```
 
 ### frontend-code
 
-Runs frontend code quality checks (linting, formatting).
+Runs frontend code quality checks by calling the project's `make lint` target.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `node-version` | Node.js version to install | Yes | |
+| `working-directory` | Directory to run the checks in | No | `"."` |
 
 **Example usage:**
 
@@ -172,11 +268,20 @@ Runs frontend code quality checks (linting, formatting).
 jobs:
   frontend-code:
     uses: plone/meta/.github/workflows/frontend-code.yml@2.x
+    with:
+      node-version: "22.x"
 ```
 
 ### frontend-i18n
 
-Validates frontend internationalization (i18n) setup.
+Validates the frontend internationalization setup by calling the project's `make i18n` target.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `node-version` | Node.js version to install | Yes | |
+| `working-directory` | Directory to run the check in | No | `"."` |
 
 **Example usage:**
 
@@ -184,11 +289,30 @@ Validates frontend internationalization (i18n) setup.
 jobs:
   frontend-i18n:
     uses: plone/meta/.github/workflows/frontend-i18n.yml@2.x
+    with:
+      node-version: "22.x"
 ```
 
 ### frontend-storybook
 
-Builds and validates Storybook stories.
+Builds Storybook with the project's `make storybook-build` target, and optionally publishes it to the `gh-pages` branch.
+
+The deployment step only runs when `deploy` is `true` **and** the workflow is running on `refs/heads/main`.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `node-version` | Node.js version to install | Yes | |
+| `working-directory` | Directory to build Storybook in | No | `"."` |
+| `deploy` | Publish the build to the `gh-pages` branch | No | `false` |
+
+**Permissions required from the caller:**
+
+| Scenario | Permissions the caller must grant |
+|----------|-----------------------------------|
+| `deploy: false` | none beyond the default |
+| `deploy: true` | `contents: write` |
 
 **Example usage:**
 
@@ -196,11 +320,23 @@ Builds and validates Storybook stories.
 jobs:
   frontend-storybook:
     uses: plone/meta/.github/workflows/frontend-storybook.yml@2.x
+    permissions:
+      contents: write
+    with:
+      node-version: "22.x"
+      deploy: true
 ```
 
 ### frontend-unit
 
-Runs frontend unit tests.
+Runs frontend unit tests by calling the project's `make ci-test` target.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `node-version` | Node.js version to install | Yes | |
+| `working-directory` | Directory to run the tests in | No | `"."` |
 
 **Example usage:**
 
@@ -208,21 +344,43 @@ Runs frontend unit tests.
 jobs:
   frontend-unit:
     uses: plone/meta/.github/workflows/frontend-unit.yml@2.x
+    with:
+      node-version: "22.x"
 ```
 
 ## Container Image Workflows
 
+The three container workflows share the same inputs and secrets.
+Use `container-image-build` to validate a build, `container-image-push` to build and publish with a registry cache, or `container-image-build-push` for the simpler combined case.
+
+```{note}
+The registry credentials are named `username` and `password`, not `registry-username` and `registry-password`.
+```
+
 ### container-image-build-push
 
-Builds and pushes a container image in a single workflow.
-Combines the build and push steps for convenience.
+Builds a container image and pushes it in a single job.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `base-tag` | Base tag applied to the image | Yes | |
+| `working-directory` | Build context directory | Yes | `"."` |
+| `image-name-prefix` | Prefix of the image name | Yes | |
+| `image-name-suffix` | Suffix of the image name | Yes | |
+| `platforms` | Target platforms to build for | No | `"linux/amd64"` |
+| `dockerfile` | Dockerfile to build | No | `"Dockerfile"` |
+| `registry` | Container registry to log in to | No | `"ghcr.io"` |
+| `build-args` | Build arguments passed to `docker/build-push-action` | No | `""` |
+| `push` | Push the image after building it | Yes | |
 
 **Secrets:**
 
 | Secret | Description | Required |
 |--------|-------------|----------|
-| `registry-username` | Container registry username | Yes |
-| `registry-password` | Container registry password or token | Yes |
+| `username` | Container registry username | Yes |
+| `password` | Container registry password or token | Yes |
 
 **Example usage:**
 
@@ -230,15 +388,43 @@ Combines the build and push steps for convenience.
 jobs:
   container-image:
     uses: plone/meta/.github/workflows/container-image-build-push.yml@2.x
+    with:
+      base-tag: "1.0.0"
+      working-directory: "backend"
+      image-name-prefix: "ghcr.io/plone"
+      image-name-suffix: "backend"
+      push: true
     secrets:
-      registry-username: ${{ secrets.REGISTRY_USERNAME }}
-      registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+      username: ${{ github.actor }}
+      password: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### container-image-build
 
-Builds a container image without pushing.
+Builds a container image and writes a registry-backed build cache, without publishing the image itself.
 Useful for validation in pull requests.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `base-tag` | Base tag applied to the image | Yes | |
+| `working-directory` | Build context directory | Yes | `"."` |
+| `image-name-prefix` | Prefix of the image name | Yes | |
+| `image-name-suffix` | Suffix of the image name | Yes | |
+| `image-cache-suffix` | Suffix of the image used to store the build cache | No | `"buildcache"` |
+| `platforms` | Target platforms to build for | No | `"linux/amd64"` |
+| `dockerfile` | Dockerfile to build | No | `"Dockerfile"` |
+| `registry` | Container registry to log in to | No | `"ghcr.io"` |
+| `build-args` | Build arguments passed to `docker/build-push-action` | No | `""` |
+| `cache-key` | Cache key used for the build cache | No | `${{ github.ref_name }}` |
+
+**Secrets:**
+
+| Secret | Description | Required |
+|--------|-------------|----------|
+| `username` | Container registry username | Yes |
+| `password` | Container registry password or token | Yes |
 
 **Example usage:**
 
@@ -246,18 +432,41 @@ Useful for validation in pull requests.
 jobs:
   container-image-build:
     uses: plone/meta/.github/workflows/container-image-build.yml@2.x
+    with:
+      base-tag: "1.0.0"
+      working-directory: "backend"
+      image-name-prefix: "ghcr.io/plone"
+      image-name-suffix: "backend"
+    secrets:
+      username: ${{ github.actor }}
+      password: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ### container-image-push
 
-Pushes a previously built container image to a registry.
+Builds a container image reusing the cache written by `container-image-build`, and pushes it to the registry.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `base-tag` | Base tag applied to the image | Yes | |
+| `working-directory` | Build context directory | Yes | `"."` |
+| `image-name-prefix` | Prefix of the image name | Yes | |
+| `image-name-suffix` | Suffix of the image name | Yes | |
+| `image-cache-suffix` | Suffix of the image holding the build cache | No | `"buildcache"` |
+| `platforms` | Target platforms to build for | No | `"linux/amd64"` |
+| `dockerfile` | Dockerfile to build | No | `"Dockerfile"` |
+| `registry` | Container registry to log in to | No | `"ghcr.io"` |
+| `build-args` | Build arguments passed to `docker/build-push-action` | No | `""` |
+| `cache-key` | Cache key used for the build cache | No | `${{ github.ref_name }}` |
 
 **Secrets:**
 
 | Secret | Description | Required |
 |--------|-------------|----------|
-| `registry-username` | Container registry username | Yes |
-| `registry-password` | Container registry password or token | Yes |
+| `username` | Container registry username | Yes |
+| `password` | Container registry password or token | Yes |
 
 **Example usage:**
 
@@ -265,9 +474,92 @@ Pushes a previously built container image to a registry.
 jobs:
   container-image-push:
     uses: plone/meta/.github/workflows/container-image-push.yml@2.x
+    with:
+      base-tag: "1.0.0"
+      working-directory: "backend"
+      image-name-prefix: "ghcr.io/plone"
+      image-name-suffix: "backend"
     secrets:
-      registry-username: ${{ secrets.REGISTRY_USERNAME }}
-      registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+      username: ${{ github.actor }}
+      password: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## tox Workflows
+
+These workflows target packages configured by the `config-package` tool, and drive the {doc}`tox environments <tox-environments>` that it generates.
+Each one runs the `init` environment first when the package defines it.
+
+Unlike the workflows above, they take no `working-directory` input: they run at the root of the checkout.
+
+(shared-workflows-coverage)=
+
+### coverage
+
+Runs the `coverage` tox environment and writes its report to the job summary.
+
+**Inputs:**
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `os-packages` | Debian packages to install with `apt-get` before running the tests (*word-split*, see {ref}`shared-workflows-quoting`) | No | `""` |
+
+**Example usage:**
+
+```yaml
+jobs:
+  coverage:
+    uses: plone/meta/.github/workflows/coverage.yml@2.x
+    with:
+      os-packages: libxml2-dev libxslt1-dev
+```
+
+### circular
+
+Runs the `circular` tox environment to report circular dependencies.
+The workflow installs `libgraphviz-dev` for you.
+
+**Example usage:**
+
+```yaml
+jobs:
+  circular:
+    uses: plone/meta/.github/workflows/circular.yml@2.x
+```
+
+### dependencies
+
+Runs the `dependencies` tox environment to report on the package's dependencies.
+
+**Example usage:**
+
+```yaml
+jobs:
+  dependencies:
+    uses: plone/meta/.github/workflows/dependencies.yml@2.x
+```
+
+### qa
+
+Runs the `lint` tox environment.
+
+**Example usage:**
+
+```yaml
+jobs:
+  qa:
+    uses: plone/meta/.github/workflows/qa.yml@2.x
+```
+
+### release_ready
+
+Runs the `release-check` tox environment to report whether the package is ready to be released.
+
+**Example usage:**
+
+```yaml
+jobs:
+  release_ready:
+    uses: plone/meta/.github/workflows/release_ready.yml@2.x
 ```
 
 ## Version pinning

--- a/news/+dependabot-composite-actions.internal
+++ b/news/+dependabot-composite-actions.internal
@@ -1,0 +1,1 @@
+Let Dependabot update the dependencies of our composite actions under `.github/actions`, which the previous `directory: "/"` configuration did not reach @ericof

--- a/news/404.documentation
+++ b/news/404.documentation
@@ -1,0 +1,1 @@
+Document the inputs, secrets and required caller permissions of every shared workflow and composite action, and explain that shell-expanded options inputs are word-split and must not contain quotes @ericof


### PR DESCRIPTION
## Summary

Two related changes to how the shared workflows are documented and maintained.

The first fixes #404. Since #400 the `*-options` inputs are expanded by the shell from an environment variable rather than substituted into the script as literal text. Unquoted parameter expansion still splits on whitespace, but it does **not** perform quote removal — so quote characters inside the value survive into the argument. The value we documented as the recommended form:

```yaml
zpretty-options: '--extend-exclude "/rss/(rss\.xml|search-rss)\.pt$"'
```

now reaches `zpretty` with the double quotes attached, matches nothing, and the deliberately excluded files get checked anyway.

Per the discussion on the issue this is documented rather than worked around in the workflow, so the injection surface that #400 closed stays closed. The reference now describes the real behaviour, marks the two affected inputs, and shows the unquoted form.

The second closes a Dependabot blind spot found while reviewing the same files.

## Documentation

`docs/sources/reference/shared-workflows.md` grew from 281 to ~530 lines:

- A new **Passing values to string inputs** section covering word splitting, quote retention and glob expansion, with the correct and broken forms side by side. It also states that an argument containing whitespace cannot currently be passed at all.
- Input tables for **all fifteen** reusable workflows. Only `backend-lint` had one.
- Five reusable workflows that were missing from the reference entirely, now grouped as **tox Workflows**: `coverage`, `circular`, `dependencies`, `qa`, `release_ready`.
- Corrected composite action tables. Between them they omitted five inputs — `setup_backend_uv` was missing `plone-version` and `working-directory`, and `setup_frontend` documented one of its four inputs.
- **Corrected container registry secret names.** They were documented as `registry-username` / `registry-password`; the workflows actually declare `username` / `password`, so the documented example could not have worked.
- `container-image-build` and `container-image-push` distinguished by the registry-backed build cache they share.
- A **Permissions** preamble recording that the reusable workflows declare no `permissions:` of their own, plus a table for `frontend-storybook` showing that `deploy: true` needs `contents: write` from the caller. Its deploy step also only runs on `refs/heads/main`, which was undocumented.

## Dependabot

For the `github-actions` ecosystem, `directory: "/"` covers `.github/workflows` and a root-level `action.yml`. Our composite actions live at `.github/actions/<name>/action.yml`, which is neither, so nothing has ever updated their dependencies.

The dependency graph confirms it: `actions/setup-node` does not appear at all — it exists only inside `setup_frontend` — and `astral-sh/setup-uv` appears only at the versions used by the workflows, never at the `v8.2.0` pinned inside the composite actions. Every commit touching `.github/actions` since it was created has been a manual bump.

Switched to the `directories` key so those directories are scanned too.

**Please sanity-check the glob.** I could not verify that `/.github/actions/*` resolves for this ecosystem — globbing is documented as a `directories` feature, and what `/` means is documented separately per ecosystem, but the docs do not say the two compose. If it matches nothing we get no coverage and no error. After merge, `actions/setup-node` appearing in the dependency graph is the signal that it worked; if it does not, the fallback is listing the three action directories explicitly.

## Out of scope

`astral-sh/setup-uv` is stale at `v7.5.0` in six workflows and `v7` in `docs.yml`, while v8 has been out since March. This is *not* the scope problem above — the dependency graph shows Dependabot sees it and skips it, and it has never opened a PR for it. Likely an ignore condition or a failing update job; both are visible from Insights → Dependency graph → Dependabot. Worth a separate issue.

## Verification

`make docs` builds clean. The only warning is pre-existing and unrelated (`how-to/setup-to-pyproject` is not in a toctree). All new cross-references resolve.

Closes #404
